### PR TITLE
Deduplicate login routes

### DIFF
--- a/src/ephemeral/session.rs
+++ b/src/ephemeral/session.rs
@@ -3,11 +3,37 @@ use rocket::http::{Cookie, Cookies, Status};
 use rocket::request::{FromRequest, Outcome, Request};
 use std::str::FromStr;
 
+use crate::controllers::sessions_controller::rocket_uri_macro_new_session;
 use crate::errors::{Result, ZauthError};
 use crate::models::user::User;
 use crate::DbConn;
+use rocket::http::uri::Origin;
+use rocket::response::Redirect;
 
 pub const SESSION_VALIDITY_MINUTES: i64 = 59;
+const REDIRECT_COOKIE: &str = "ZAUTH_REDIRECT";
+const SESSION_COOKIE: &str = "ZAUTH_SESSION";
+
+pub fn ensure_logged_in_and_redirect(
+	mut cookies: Cookies,
+	uri: Origin,
+) -> Redirect
+{
+	cookies.add_private(Cookie::new(REDIRECT_COOKIE, uri.to_string()));
+	Redirect::to(uri!(new_session))
+}
+
+pub fn stored_redirect_or(mut cookies: Cookies, fallback: Origin) -> Redirect {
+	let location: Origin =
+		if let Some(cookie) = cookies.get_private(REDIRECT_COOKIE) {
+			let stored = Origin::parse_owned(String::from(cookie.value())).ok();
+			cookies.remove_private(cookie);
+			stored.unwrap_or(fallback)
+		} else {
+			fallback
+		};
+	Redirect::to(location.to_string())
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Session {
@@ -23,15 +49,15 @@ impl Session {
 		}
 	}
 
-	pub fn add_to_cookies(user: User, cookies: &mut Cookies) {
+	pub fn login(user: User, cookies: &mut Cookies) {
 		let session = Session::new(user);
 		let session_str = serde_urlencoded::to_string(session).unwrap();
-		let session_cookie = Cookie::new("session", session_str);
+		let session_cookie = Cookie::new(SESSION_COOKIE, session_str);
 		cookies.add_private(session_cookie);
 	}
 
 	pub fn destroy(cookies: &mut Cookies) {
-		cookies.remove_private(Cookie::named("session"))
+		cookies.remove_private(Cookie::named(SESSION_COOKIE))
 	}
 
 	pub fn user(&self, conn: &DbConn) -> Result<User> {
@@ -57,7 +83,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for Session {
 	fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
 		let session = request
 			.cookies()
-			.get_private("session")
+			.get_private(SESSION_COOKIE)
 			.map(|cookie| Session::from_str(cookie.value()));
 		match session {
 			Some(Ok(session)) => Outcome::Success(session),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,8 @@ pub enum ZauthError {
 	ValidationError(#[from] ValidationErrors),
 	#[error("Request error {0:?}")]
 	RequestError(#[from] RequestError),
+	#[error("OAuth error: {0:?}")]
+	OAuth(#[from] OAuthError),
 	#[error("Authentication error {0:?}")]
 	AuthError(#[from] AuthenticationError),
 	#[error("Login error {0:?}")]
@@ -97,6 +99,10 @@ pub enum InternalError {
 	MailerStopped(#[from] SendError<Message>),
 	#[error("Mail queue full")]
 	MailQueueFull(#[from] TrySendError<Message>),
+	#[error("Bincode error")]
+	BincodeError(#[from] Box<bincode::ErrorKind>),
+	#[error("B64 decode error")]
+	Base64DecodeError(#[from] base64::DecodeError),
 }
 pub type InternalResult<T> = std::result::Result<T, InternalError>;
 
@@ -147,6 +153,15 @@ pub enum LaunchError {
 	InvalidEmail(#[from] lettre::address::AddressError),
 	#[error("Failed to create SMTP transport")]
 	SMTPError(#[from] lettre::transport::smtp::error::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum OAuthError {
+	#[error(
+		"The cookie used for storing OAuth information is invalid or has \
+		 expired."
+	)]
+	InvalidCookie,
 }
 
 pub enum Either<R, E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,6 @@ fn assemble(rocket: Rocket) -> Rocket {
 				oauth_controller::authorize,
 				oauth_controller::grant_get,
 				oauth_controller::grant_post,
-				oauth_controller::login_get,
-				oauth_controller::login_post,
 				oauth_controller::token,
 				pages_controller::home_page,
 				sessions_controller::create_session,

--- a/templates/oauth/grant.html
+++ b/templates/oauth/grant.html
@@ -7,7 +7,6 @@
   </div>
   <div class="center_card">
     <form action="grant" method="post">
-      <input type="hidden" name="state" value="{{ state }}">
       <h1>Grant {{ client_name }} access?</h1>
       <div class="buttons">
         <button type="submit" name="grant" value="true">Yes</button>

--- a/templates/session/login.html
+++ b/templates/session/login.html
@@ -11,7 +11,6 @@
     {% when None %}
     {% endmatch %}
     <form action="/login" method="post">
-      <input type="hidden" name="state" value="{{ state }}">
       <input type="text" placeholder="Username" name="username" id="name" required>
       <input type="password" placeholder="Password" name="password" id="password" required>
       <input type="submit" value="Login" class="loginbutton">


### PR DESCRIPTION
Apparently we had two routes to login (`/oauth/login` and `/login`, #16), so I've added a mechanism to store a `redirect_uri` to redirect clients to when once they are logged in, so they can continue their login flow.

This also makes it possible to redirect users to the login page instead of showing them an "unauthorized" page. But this isn't implemented yet.

I've also put the OAuth state in a cookie, to avoid passing it trough URL parameters and hidden form bodies. A client needs to have cookies enabled to be logged in anyway...