### PR TITLE
Migrate to Rocket v5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,46 +66,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "askama"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d298738b6e47e1034e560e5afe63aa488fea34e25ec11b855a76f0d7b8e73134"
+version = "0.11.0-beta.1"
+source = "git+https://github.com/djc/askama.git?rev=8142963#81429636eb295ec03ef35cf77648d1626970fd4e"
 dependencies = [
  "askama_derive",
  "askama_escape",
  "askama_shared",
- "mime 0.3.16",
+ "mime",
  "mime_guess",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2925c4c290382f9d2fa3d1c1b6a63fa1427099721ecca4749b154cc9c25522"
+version = "0.11.0-beta.1"
+source = "git+https://github.com/djc/askama.git?rev=8142963#81429636eb295ec03ef35cf77648d1626970fd4e"
 dependencies = [
  "askama_shared",
- "proc-macro2 1.0.28",
- "syn 1.0.74",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
 name = "askama_escape"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c108c1a94380c89d2215d0ac54ce09796823cca0fd91b299cfff3b33e346fb"
+version = "0.10.2"
+source = "git+https://github.com/djc/askama.git?rev=8142963#81429636eb295ec03ef35cf77648d1626970fd4e"
 
 [[package]]
 name = "askama_rocket"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40428c13bd027adfd481391729b85bf9961b59e5b21bb55e80f603d19d054583"
+version = "0.11.0-rc.2"
+source = "git+https://github.com/djc/askama.git?rev=8142963#81429636eb295ec03ef35cf77648d1626970fd4e"
 dependencies = [
  "askama",
  "rocket",
@@ -113,20 +103,40 @@ dependencies = [
 
 [[package]]
 name = "askama_shared"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2582b77e0f3c506ec4838a25fa8a5f97b9bed72bb6d3d272ea1c031d8bd373bc"
+version = "0.12.0-beta.1"
+source = "git+https://github.com/djc/askama.git?rev=8142963#81429636eb295ec03ef35cf77648d1626970fd4e"
 dependencies = [
  "askama_escape",
  "humansize",
- "nom",
+ "nom 7.0.0",
  "num-traits",
- "percent-encoding 2.1.0",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "percent-encoding",
+ "proc-macro2",
+ "quote",
  "serde",
- "syn 1.0.74",
+ "syn",
  "toml 0.5.8",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -136,6 +146,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
+name = "async-trait"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
+dependencies = [
+ "autocfg 1.0.1",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,7 +173,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -159,20 +189,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base64"
-version = "0.9.3"
+name = "base-x"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "binascii"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bincode"
@@ -231,10 +263,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
@@ -264,8 +308,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
- "winapi 0.3.9",
+ "time 0.1.43",
+ "winapi",
 ]
 
 [[package]]
@@ -287,19 +331,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.11.4"
+name = "const_fn"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f6044740a4a516b8aac14c140cdf35c1a640b1bd6b98b6224e49143b2f1566"
+checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
+
+[[package]]
+name = "cookie"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d"
 dependencies = [
  "aes-gcm",
- "base64 0.13.0",
+ "base64",
  "hkdf",
- "hmac 0.10.1",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "rand 0.8.4",
  "sha2",
- "time",
+ "subtle",
+ "time 0.2.27",
+ "version_check",
 ]
 
 [[package]]
@@ -420,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "devise"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e04ba2d03c5fa0d954c061fc8c9c288badadffc272ebb87679a89846de3ed3"
+checksum = "50c7580b072f1c8476148f16e0a0d5dedddab787da98d86c5082c5e9ed8ab595"
 dependencies = [
  "devise_codegen",
  "devise_core",
@@ -430,24 +481,25 @@ dependencies = [
 
 [[package]]
 name = "devise_codegen"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066ceb7928ca93a9bedc6d0e612a8a0424048b0ab1f75971b203d01420c055d7"
+checksum = "123c73e7a6e51b05c75fe1a1b2f4e241399ea5740ed810b0e3e6cacd9db5e7b2"
 dependencies = [
  "devise_core",
- "quote 0.6.13",
+ "quote",
 ]
 
 [[package]]
 name = "devise_core"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c59b22b5e3ec0ea55c7847e5f358d340f3a8d6d53a5cf4f1564967f96487"
+checksum = "841ef46f4787d9097405cac4e70fb8644fc037b526e8c14054247c0263c400d0"
 dependencies = [
  "bitflags",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -471,9 +523,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70806b70be328e646f243680a3fc93b3cfdd6db373faa5110660a5dd5af243bc"
 dependencies = [
  "heck",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -482,9 +534,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -507,6 +559,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,16 +589,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.14"
+name = "figment"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
+checksum = "790b4292c72618abbab50f787a477014fe15634f96291de45672ce46afe122df"
 dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall",
- "winapi 0.3.9",
+ "atomic",
+ "pear",
+ "serde",
+ "toml 0.5.8",
+ "uncased",
+ "version_check",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -549,26 +630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
-]
-
-[[package]]
-name = "fsevent"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
-dependencies = [
- "bitflags",
- "fsevent-sys",
-]
-
-[[package]]
-name = "fsevent-sys"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
-dependencies = [
- "libc",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -578,26 +640,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "futures"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+dependencies = [
+ "autocfg 1.0.1",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+
+[[package]]
+name = "futures-task"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+
+[[package]]
+name = "futures-util"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+dependencies = [
+ "autocfg 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d9279ca822891c1a4dae06d185612cf8fc6acfe5dff37781b41297811b12ee"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
+]
 
 [[package]]
 name = "generic-array"
@@ -606,7 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check 0.9.3",
+ "version_check",
 ]
 
 [[package]]
@@ -646,6 +799,25 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "hashbrown"
@@ -719,14 +891,36 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi 0.3.9",
+ "winapi",
+]
+
+[[package]]
+name = "http"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.6"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
@@ -742,32 +936,26 @@ checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
- "base64 0.9.3",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
- "language-tags",
- "log 0.3.9",
- "mime 0.2.6",
- "num_cpus",
- "time",
- "traitobject",
- "typeable",
- "unicase 1.4.2",
- "url 1.7.2",
-]
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
 ]
 
 [[package]]
@@ -795,27 +983,14 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown 0.11.2",
+ "serde",
 ]
 
 [[package]]
-name = "inotify"
-version = "0.7.1"
+name = "inlinable_string"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
-dependencies = [
- "bitflags",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
+checksum = "3094308123a0e9fd59659ce45e22de9f53fc1d2ac6e1feb9fef988e4f76cad77"
 
 [[package]]
 name = "instant"
@@ -827,35 +1002,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -864,42 +1014,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lettre"
 version = "0.10.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8697ded52353bdd6fec234b3135972433397e86d0493d9fc38fbf407b7c106a"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "fastrand",
  "hostname",
  "httpdate",
- "idna 0.2.3",
- "mime 0.3.16",
+ "idna",
+ "mime",
  "native-tls",
- "nom",
+ "nom 6.2.1",
  "once_cell",
  "quoted_printable",
  "r2d2",
  "regex",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
 ]
 
 [[package]]
@@ -929,20 +1060,24 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.14",
-]
-
-[[package]]
-name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "loom"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2111607c723d7857e0d8299d5ce7a0bf4b844d3e44f8de136b13da513eaf8fc4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1011,18 +1146,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
 dependencies = [
  "migrations_internals",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
-]
-
-[[package]]
-name = "mime"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-dependencies = [
- "log 0.3.9",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1037,51 +1163,56 @@ version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
- "mime 0.3.16",
- "unicase 2.6.0",
+ "mime",
+ "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6595bb28ed34f43c3fe088e48f6cfb2e033cab45f25a5384d5fdf564fbc8c4b2"
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
- "log 0.4.14",
+ "log",
  "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio-extras"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
-dependencies = [
- "lazycell",
- "log 0.4.14",
- "mio",
- "slab",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
+]
+
+[[package]]
+name = "multer"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408327e2999b839cd1af003fc01b2019a6c10a1361769542203f6fedc5179680"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "mime",
+ "spin",
+ "tokio",
+ "tokio-util",
+ "twoway",
+ "version_check",
 ]
 
 [[package]]
@@ -1092,7 +1223,7 @@ checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.14",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -1103,17 +1234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "nom"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,27 +1241,28 @@ checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
 dependencies = [
  "bitvec",
  "funty",
- "lexical-core",
  "memchr",
- "version_check 0.9.3",
+ "version_check",
 ]
 
 [[package]]
-name = "notify"
-version = "4.0.17"
+name = "nom"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257"
+checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
 dependencies = [
- "bitflags",
- "filetime",
- "fsevent",
- "fsevent-sys",
- "inotify",
- "libc",
- "mio",
- "mio-extras",
- "walkdir",
- "winapi 0.3.9",
+ "memchr",
+ "minimal-lexical",
+ "version_check",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1264,7 +1385,7 @@ dependencies = [
  "rand 0.6.5",
  "rustc_version",
  "smallvec 0.6.14",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1278,42 +1399,49 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec 1.6.1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "pear"
-version = "0.1.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5320f212db967792b67cfe12bd469d08afd6318a249bd917d5c19bc92200ab8a"
+checksum = "15e44241c5e4c868e3eaa78b7c1848cadd6344ed4f54d029832d32b415a58702"
 dependencies = [
+ "inlinable_string",
  "pear_codegen",
-]
-
-[[package]]
-name = "pear_codegen"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc1c836fdc3d1ef87c348b237b5b5c4dff922156fb2d968f57734f9669768ca"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
- "version_check 0.9.3",
  "yansi",
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "1.0.1"
+name = "pear_codegen"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+checksum = "82a5ca643c2303ecb740d506539deba189e16f2754040a42901cd8105d0282d0"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1354,10 +1482,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
- "version_check 0.9.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]
@@ -1366,19 +1494,22 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "version_check 0.9.3",
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "0.4.30"
+name = "proc-macro-hack"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1386,7 +1517,20 @@ version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
- "unicode-xid 0.2.2",
+ "unicode-xid",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -1406,20 +1550,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.28",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1434,7 +1569,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
- "log 0.4.14",
+ "log",
  "parking_lot 0.11.1",
  "scheduled-thread-pool",
 ]
@@ -1461,7 +1596,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1596,7 +1731,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1610,7 +1745,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1651,6 +1786,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300f2a835d808734ee295d45007adacb9ebb29dd3ae2424acfa17930cae541da"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c38e3aecd2b21cb3959637b883bb3714bc7e43f0268b9a29d3743ee3e55cdd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,88 +1828,114 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "rocket"
-version = "0.4.10"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7ab1dfdc75bb8bd2be381f37796b1b300c45a3c9145b34d86715e8dd90bf28"
+checksum = "0a71c18c42a0eb15bf3816831caf0dad11e7966f2a41aaf486a701979c4dd1f2"
 dependencies = [
+ "async-stream",
+ "async-trait",
+ "atomic",
  "atty",
- "base64 0.13.0",
- "log 0.4.14",
+ "binascii",
+ "bytes",
+ "either",
+ "figment",
+ "futures",
+ "indexmap",
+ "log",
  "memchr",
+ "multer",
  "num_cpus",
- "pear",
+ "parking_lot 0.11.1",
+ "pin-project-lite",
+ "rand 0.8.4",
+ "ref-cast",
  "rocket_codegen",
  "rocket_http",
+ "serde",
+ "serde_json",
  "state",
- "time",
- "toml 0.4.10",
- "version_check 0.9.3",
+ "tempfile",
+ "time 0.2.27",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "ubyte",
+ "version_check",
  "yansi",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.4.10"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729e687d6d2cf434d174da84fb948f7fef4fac22d20ce94ca61c28b72dbcf9f"
+checksum = "66f5fa462f7eb958bba8710c17c5d774bbbd59809fa76fb1957af7e545aea8bb"
 dependencies = [
  "devise",
  "glob",
  "indexmap",
- "quote 0.6.13",
+ "proc-macro2",
+ "quote",
  "rocket_http",
- "version_check 0.9.3",
- "yansi",
-]
-
-[[package]]
-name = "rocket_contrib"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6303dccab46dce6c7ac26c9b9d8d8cde1b19614b027c3f913be6611bff6d9b"
-dependencies = [
- "diesel",
- "log 0.4.14",
- "notify",
- "r2d2",
- "rocket",
- "rocket_contrib_codegen",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "rocket_contrib_codegen"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0f2cbcb6c09b3ac0acdf77682ff8c9d1f317361498a773ee50b32be7fddfe2b"
-dependencies = [
- "devise",
- "quote 0.6.13",
- "version_check 0.9.3",
- "yansi",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "rocket_http"
-version = "0.4.10"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6131e6e6d38a9817f4a494ff5da95971451c2eb56a53915579fc9c80f6ef0117"
+checksum = "23c8b7d512d2fcac2316ebe590cde67573844b99e6cc9ee0f53375fa16e25ebd"
 dependencies = [
  "cookie",
+ "either",
+ "http",
  "hyper",
  "indexmap",
+ "log",
+ "memchr",
+ "mime",
+ "parking_lot 0.11.1",
  "pear",
- "percent-encoding 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "ref-cast",
+ "serde",
  "smallvec 1.6.1",
+ "stable-pattern",
  "state",
- "time",
- "unicode-xid 0.1.0",
+ "time 0.2.27",
+ "tokio",
+ "uncased",
+]
+
+[[package]]
+name = "rocket_sync_db_pools"
+version = "0.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38cfdfebd552d075c368e641c88a5cd6ce1c58c5c710548aeb777abb48830f4b"
+dependencies = [
+ "diesel",
+ "r2d2",
+ "rocket",
+ "rocket_sync_db_pools_codegen",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "rocket_sync_db_pools_codegen"
+version = "0.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267808c094db5366e1d8925aaf9f2ce05ff9b3bd92cb18c7040a1fe219c2e25"
+dependencies = [
+ "devise",
+ "quote",
 ]
 
 [[package]]
@@ -1767,25 +1948,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -1794,7 +1966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1805,6 +1977,12 @@ checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
  "parking_lot 0.11.1",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -1871,9 +2049,9 @@ version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1913,6 +2091,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+
+[[package]]
 name = "sha2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +2107,15 @@ dependencies = [
  "cpufeatures",
  "digest",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1947,22 +2140,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
+name = "socket2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+
+[[package]]
+name = "stable-pattern"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "state"
-version = "0.4.2"
+name = "standback"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3015a7d0a5fd5105c91c3710d42f9ccf0abfb287d62206484dcc67f9569a6483"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
+name = "state"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "87cf4f5369e6d3044b5e365c9690f451516ac8f0954084622b49ea3fde2f6de5"
+dependencies = [
+ "loom",
+]
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "subtle"
@@ -1972,24 +2245,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "unicode-xid 0.2.2",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2009,7 +2271,7 @@ dependencies = [
  "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2027,9 +2289,9 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2053,7 +2315,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
 ]
 
 [[package]]
@@ -2070,6 +2370,61 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+dependencies = [
+ "autocfg 1.0.1",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml"
@@ -2090,16 +2445,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
+name = "tower-service"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
-name = "typeable"
-version = "0.1.2"
+name = "tracing"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "twoway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57ffb460d7c24cd6eda43694110189030a3d1dfe418416d9468fd1c1d290b47"
+dependencies = [
+ "memchr",
+ "unchecked-index",
+]
 
 [[package]]
 name = "typenum"
@@ -2108,13 +2493,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
-name = "unicase"
-version = "1.4.2"
+name = "ubyte"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+checksum = "42756bb9e708855de2f8a98195643dff31a97f0485d90d8467b39dc24be9e8fe"
 dependencies = [
- "version_check 0.1.5",
+ "serde",
 ]
+
+[[package]]
+name = "uncased"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
+dependencies = [
+ "serde",
+ "version_check",
+]
+
+[[package]]
+name = "unchecked-index"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicase"
@@ -2122,7 +2523,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.3",
+ "version_check",
 ]
 
 [[package]]
@@ -2151,12 +2552,6 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
@@ -2173,25 +2568,14 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.3",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2206,13 +2590,13 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d0f08911ab0fee2c5009580f04615fa868898ee57de10692a45da0c3bcc3e5e"
 dependencies = [
- "idna 0.2.3",
+ "idna",
  "lazy_static",
  "regex",
  "serde",
  "serde_derive",
  "serde_json",
- "url 2.2.2",
+ "url",
  "validator_types",
 ]
 
@@ -2225,10 +2609,10 @@ dependencies = [
  "if_chain",
  "lazy_static",
  "proc-macro-error",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "regex",
- "syn 1.0.74",
+ "syn",
  "validator_types",
 ]
 
@@ -2238,8 +2622,8 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded9d97e1d42327632f5f3bae6403c04886e2de3036261ef42deebd931a6a291"
 dependencies = [
- "proc-macro2 1.0.28",
- "syn 1.0.74",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -2250,25 +2634,18 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-
-[[package]]
-name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
-name = "walkdir"
-version = "2.3.2"
+name = "want"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "same-file",
- "winapi 0.3.9",
- "winapi-util",
+ "log",
+ "try-lock",
 ]
 
 [[package]]
@@ -2284,10 +2661,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
-name = "winapi"
-version = "0.2.8"
+name = "wasm-bindgen"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "winapi"
@@ -2300,41 +2725,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-
-[[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
 
 [[package]]
 name = "wyz"
@@ -2354,7 +2754,7 @@ version = "0.1.0"
 dependencies = [
  "askama",
  "askama_rocket",
- "base64 0.13.0",
+ "base64",
  "bincode",
  "chrono",
  "diesel",
@@ -2368,7 +2768,7 @@ dependencies = [
  "rand 0.8.4",
  "regex",
  "rocket",
- "rocket_contrib",
+ "rocket_sync_db_pools",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2018"
 authors = ["Rien Maertens <rien.maertens@posteo.be>"]
 
 [dependencies]
-askama = { version = "0.10", features = ["with-rocket", "mime", "mime_guess"] }
-askama_rocket = "0.10"
+# askama = { version = "0.10", features = ["with-rocket", "mime", "mime_guess"] }
+askama = { git = "https://github.com/djc/askama.git", rev = "8142963", features = ["with-rocket", "mime", "mime_guess"] }
+# askama_rocket = "0.10"
+askama_rocket = { git = "https://github.com/djc/askama.git", rev = "8142963" }
 base64 = "0.13"
 bincode = "1.0"
 pwhash = "0.3"
@@ -17,7 +19,7 @@ urlencoding = "1.0"
 toml = "0.4"
 rand = "0.8"
 regex = "1.0"
-rocket = "0.4.2"
+rocket = { version = "0.5.0-rc.1", features = [ "json", "secrets" ] }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
@@ -33,7 +35,6 @@ threads_pool = "0.2.6"
 validator = "0.14"
 validator_derive = "0.14"
 
-[dependencies.rocket_contrib]
-version = "0.4.2"
-default-features = false
-features = ["json", "diesel_postgres_pool",  "serve"]
+[dependencies.rocket_sync_db_pools]
+version = "0.1.0-rc.1"
+features = ["diesel_postgres_pool"]

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,11 +1,22 @@
-[development.databases.postgresql_database]
-url = "postgresql://zauth:zauth@localhost/zauth"
+[default]
+authorization_token_validity_seconds = 300
+secure_token_length = 64
+bcrypt_cost = 12
+base_url = "http://localhost:8000"
+mail_queue_size = 32
+mail_queue_wait_seconds = 1
+mail_from = "zauth@localhost"
+mail_server = "stub"
 
-[development]
+[debug]
 secret_key = "1vwCFFPSdQya895gNiO556SzmfShG6MokstgttLvwjw="
 bcrypt_cost = 4
+seed_database = true
 
-[production]
+[debug.databases.postgresql_database]
+url = "postgresql://zauth:zauth@localhost/zauth"
+
+[release]
 # Values you want to fill in for production use
 # secret_key =  # used to encrypt cookies (generate a new one!)
 # base_url =    # URL where the application is hosten (e.g. https://auth.zeus.gent)
@@ -14,5 +25,5 @@ bcrypt_cost = 4
 
 # See src/config.rs for all the possible config values and their defaults
 
-[production.databases.postgresql_database]
+[release.databases.postgresql_database]
 url = "postgresql://zauth:zauth@database/zauth"

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,9 +6,9 @@ pub struct Config {
 	pub authorization_token_validity_seconds: usize,
 	pub secure_token_length: usize,
 	pub bcrypt_cost: u32,
-	pub base_url: &'static str,
+	pub base_url: String,
 	pub mail_queue_size: usize,
 	pub mail_queue_wait_seconds: u64,
-	pub mail_from: &'static str,
-	pub mail_server: &'static str,
+	pub mail_from: String,
+	pub mail_server: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,42 +1,14 @@
-use pwhash::bcrypt;
-use std::convert::TryFrom;
-use toml::de::Error;
+use rocket::serde::Deserialize;
 
-macro_rules! config_options {
-    ($($name:ident: $type:ty = $default:expr),+$(,)?) => {
-    	#[derive(Debug, Clone)]
-    	pub struct Config {
-			$(
-				pub $name: $type,
-			)+
-    	}
-    	impl TryFrom<&rocket::Config> for Config {
-			type Error = Error;
-
-			fn try_from(config: &rocket::Config) -> Result<Self, Self::Error> {
-				Ok(Config {
-					$(
-						$name: {
-							if let Some(value) = config.extras.get("$name") {
-							 	value.to_owned().try_into()?
-							} else {
-								$default
-							}
-						},
-					)+
-				})
-			}
-		}
-    };
+#[derive(Debug, Deserialize, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct Config {
+	pub authorization_token_validity_seconds: usize,
+	pub secure_token_length: usize,
+	pub bcrypt_cost: u32,
+	pub base_url: &'static str,
+	pub mail_queue_size: usize,
+	pub mail_queue_wait_seconds: u64,
+	pub mail_from: &'static str,
+	pub mail_server: &'static str,
 }
-
-config_options!(
-	authorization_token_validity_seconds: usize = 300,
-	secure_token_length: usize = 64,
-	bcrypt_cost: u32 = bcrypt::DEFAULT_COST,
-	base_url: &'static str = "http://localhost:8000",
-	mail_queue_size: usize = 32,
-	mail_queue_wait_seconds: u64 = 1,
-	mail_from: &'static str = "zauth@localhost",
-	mail_server: &'static str = "stub"
-);

--- a/src/controllers/pages_controller.rs
+++ b/src/controllers/pages_controller.rs
@@ -9,18 +9,18 @@ use crate::models::user::User;
 use crate::DbConn;
 
 #[get("/")]
-pub fn home_page(
+pub async fn home_page<'r>(
 	session: Option<UserSession>,
-	conn: DbConn,
-) -> Result<Either<Redirect, impl Responder<'static>>> {
+	db: DbConn,
+) -> Result<Either<Redirect, impl Responder<'r, 'static>>> {
 	match session {
 		None => Ok(Either::Right(template! {
 			"pages/home.html";
-			clients:      Vec<Client>  = Client::all(&conn)?,
-			users:        Vec<User>    = User::all(&conn)?,
+			clients:      Vec<Client>  = Client::all(&db).await?,
+			users:        Vec<User>    = User::all(&db).await?,
 		})),
 		Some(session) => {
-			Ok(Either::Left(Redirect::to(uri!(show_user: session.user.id))))
+			Ok(Either::Left(Redirect::to(uri!(show_user(session.user.id)))))
 		},
 	}
 }

--- a/src/controllers/sessions_controller.rs
+++ b/src/controllers/sessions_controller.rs
@@ -1,5 +1,4 @@
-use rocket::http::Cookies;
-use rocket::request::Form;
+use rocket::form::Form;
 use rocket::response::{Redirect, Responder};
 
 use crate::controllers::pages_controller::rocket_uri_macro_home_page;
@@ -7,12 +6,13 @@ use crate::ephemeral::session::{stored_redirect_or, Session, UserSession};
 use crate::errors::{Either, Result, ZauthError};
 use crate::models::user::User;
 use crate::DbConn;
+use rocket::http::CookieJar;
 
 #[get("/login")]
-pub fn new_session(
+pub fn new_session<'r>(
 	session: Option<UserSession>,
-	cookies: Cookies,
-) -> Either<Redirect, impl Responder<'static>> {
+	cookies: &CookieJar,
+) -> Either<Redirect, impl Responder<'r, 'static>> {
 	match session {
 		None => Either::Right(template! {
 			"session/login.html";
@@ -23,7 +23,7 @@ pub fn new_session(
 }
 
 #[get("/logout")]
-pub fn delete_session(session: UserSession) -> impl Responder<'static> {
+pub fn delete_session<'r>(session: UserSession) -> impl Responder<'r, 'static> {
 	template! {
 		"session/logout.html";
 		current_user: User = session.user
@@ -37,13 +37,13 @@ pub struct LoginFormData {
 }
 
 #[post("/login", data = "<form>")]
-pub fn create_session(
+pub async fn create_session<'r>(
 	form: Form<LoginFormData>,
-	mut cookies: Cookies,
-	conn: DbConn,
-) -> Result<Either<Redirect, impl Responder<'static>>> {
+	cookies: &'r CookieJar<'_>,
+	db: DbConn,
+) -> Result<Either<Redirect, impl Responder<'r, 'static>>> {
 	let form = form.into_inner();
-	match User::find_and_authenticate(&form.username, &form.password, &conn) {
+	match User::find_and_authenticate(form.username, form.password, &db).await {
 		Err(ZauthError::LoginError(login_error)) => {
 			Ok(Either::Right(template! {
 				"session/login.html";
@@ -51,7 +51,7 @@ pub fn create_session(
 			}))
 		},
 		Ok(user) => {
-			Session::login(user, &mut cookies);
+			Session::login(user, cookies);
 			Ok(Either::Left(stored_redirect_or(cookies, uri!(home_page))))
 		},
 		Err(err) => Err(err),
@@ -59,7 +59,7 @@ pub fn create_session(
 }
 
 #[post("/logout")]
-pub fn destroy_session(mut cookies: Cookies) -> Redirect {
-	Session::destroy(&mut cookies);
+pub fn destroy_session(cookies: &CookieJar) -> Redirect {
+	Session::destroy(cookies);
 	Redirect::to("/")
 }

--- a/src/db_seed.rs
+++ b/src/db_seed.rs
@@ -1,0 +1,84 @@
+use std::default::Default;
+use rocket::fairing::{Fairing, Info, Kind};
+use rocket::{Rocket, Orbit};
+use crate::DbConn;
+
+pub struct Seeder {
+    empty_db: bool,
+    clients_to_seed: usize,
+    users_to_seed: usize,
+    admin_password: Option<String>,
+    client_name: Option<String>,
+}
+
+impl Default for Seeder {
+    fn default() -> Self {
+        Seeder {
+            empty_db: false,
+            clients_to_seed: 0,
+            users_to_seed: 0,
+            admin_password: None,
+            client_name: None,
+        }
+    }
+}
+
+impl Seeder {
+    fn from_env() {
+        let mut seeder = Self::default();
+        if let Ok(_) = std::env::var("ZAUTH_EMPTY_DB") {
+            seeder.empty_db = true;
+        }
+        if let Ok(number) = std::env::var("ZAUTH_SEED_CLIENT") {
+            match number.parse() {
+                Ok(num) => seeder.clients_to_seed = num,
+                Err(_) =>
+                    eprintln!(
+                        "ZAUTH_SEED_CLIENT=\"{}\" error, expected number",
+                        number
+                    ),
+            };
+        }
+        if let Ok(number) = std::env::var("ZAUTH_SEED_USER") {
+            match number.parse() {
+                Ok(num) => seeder.users_to_seed = num,
+                Err(_) =>
+                eprintln!(
+                    "ZAUTH_SEED_USER=\"{}\" error, expected number",
+                    number
+                ),
+            };
+        }
+        if let Ok(pw) = std::env::var("ZAUTH_ADMIN_PASSWORD") {
+            seeder.admin_password = Some(pw);
+        }
+        if let Ok(client) = std::env::var("ZAUTH_CLIENT_NAME") {
+            seeder.client_name = Some(client);
+        }
+    }
+
+    async fn delete_all(conn: &DbConn) {
+        todo!()
+    }
+
+    async fn seed_client(conn: &DbConn) {
+        todo!()
+    }
+
+    async fn seed_user(conn: &DbConn) {
+        todo!()
+    }
+}
+
+impl Fairing for Seeder {
+    fn info(&self) -> Info {
+        Info {
+            name: "Seed database",
+            kind: Kind::Liftoff,
+        }
+    }
+
+    async fn on_liftoff(&self, rocket: &Rocket<Orbit>) {
+
+    }
+}

--- a/src/db_seed.rs
+++ b/src/db_seed.rs
@@ -1,84 +1,155 @@
-use std::default::Default;
-use rocket::fairing::{Fairing, Info, Kind};
-use rocket::{Rocket, Orbit};
+use crate::errors::{Result, ZauthError};
+use crate::models::client::{Client, NewClient};
+use crate::models::user::schema::users;
+use crate::models::user::{NewUser, User};
+use crate::util::random_token;
 use crate::DbConn;
+use diesel::RunQueryDsl;
+use rocket::fairing::{Fairing, Info, Kind};
+use rocket::{Orbit, Rocket};
+use std::default::Default;
 
 pub struct Seeder {
-    empty_db: bool,
-    clients_to_seed: usize,
-    users_to_seed: usize,
-    admin_password: Option<String>,
-    client_name: Option<String>,
+	empty_db:            bool,
+	clients_to_seed:     usize,
+	users_to_seed:       usize,
+	admin_password:      Option<String>,
+	client_name:         Option<String>,
+	client_redirect_uri: Option<String>,
 }
 
 impl Default for Seeder {
-    fn default() -> Self {
-        Seeder {
-            empty_db: false,
-            clients_to_seed: 0,
-            users_to_seed: 0,
-            admin_password: None,
-            client_name: None,
-        }
-    }
+	fn default() -> Self {
+		Seeder {
+			empty_db:            false,
+			clients_to_seed:     0,
+			users_to_seed:       0,
+			admin_password:      None,
+			client_name:         None,
+			client_redirect_uri: None,
+		}
+	}
 }
 
 impl Seeder {
-    fn from_env() {
-        let mut seeder = Self::default();
-        if let Ok(_) = std::env::var("ZAUTH_EMPTY_DB") {
-            seeder.empty_db = true;
-        }
-        if let Ok(number) = std::env::var("ZAUTH_SEED_CLIENT") {
-            match number.parse() {
-                Ok(num) => seeder.clients_to_seed = num,
-                Err(_) =>
-                    eprintln!(
-                        "ZAUTH_SEED_CLIENT=\"{}\" error, expected number",
-                        number
-                    ),
-            };
-        }
-        if let Ok(number) = std::env::var("ZAUTH_SEED_USER") {
-            match number.parse() {
-                Ok(num) => seeder.users_to_seed = num,
-                Err(_) =>
-                eprintln!(
-                    "ZAUTH_SEED_USER=\"{}\" error, expected number",
-                    number
-                ),
-            };
-        }
-        if let Ok(pw) = std::env::var("ZAUTH_ADMIN_PASSWORD") {
-            seeder.admin_password = Some(pw);
-        }
-        if let Ok(client) = std::env::var("ZAUTH_CLIENT_NAME") {
-            seeder.client_name = Some(client);
-        }
-    }
+	fn from_env() {
+		let mut seeder = Self::default();
+		if let Ok(_) = std::env::var("ZAUTH_EMPTY_DB") {
+			seeder.empty_db = true;
+		}
+		if let Ok(number) = std::env::var("ZAUTH_SEED_CLIENTS") {
+			match number.parse() {
+				Ok(num) => seeder.clients_to_seed = num,
+				Err(_) => eprintln!(
+					"ZAUTH_SEED_CLIENT=S\"{}\" error, expected number",
+					number
+				),
+			};
+		}
+		if let Ok(number) = std::env::var("ZAUTH_SEED_USERS") {
+			match number.parse() {
+				Ok(num) => seeder.users_to_seed = num,
+				Err(_) => eprintln!(
+					"ZAUTH_SEED_USERS=\"{}\" error, expected number",
+					number
+				),
+			};
+		}
+		if let Ok(pw) = std::env::var("ZAUTH_ADMIN_PASSWORD") {
+			seeder.admin_password = Some(pw);
+		}
+		if let Ok(client) = std::env::var("ZAUTH_CLIENT_NAME") {
+			seeder.client_name = Some(client);
+		}
+		if let Ok(uri) = std::env::var("ZAUTH_CLIENT_REDIRECT_URI") {
+			seeder.client_redirect_uri = Some(uri);
+		}
+	}
 
-    async fn delete_all(conn: &DbConn) {
-        todo!()
-    }
+	async fn delete_all(self, db: &DbConn) -> Result<()> {
+		db.run(|conn| {
+			diesel::delete(users::table)
+				.execute(conn)
+				.map_err(ZauthError::from)
+		})
+		.await?;
+		println!("Database cleared");
+		Ok(())
+	}
 
-    async fn seed_client(conn: &DbConn) {
-        todo!()
-    }
+	async fn seed_clients(self, db: &DbConn) -> Result<()> {
+		for i in 1..self.clients_to_seed {
+			let mut client = Client::create(
+				NewClient {
+					name: format!("Test client {}", i),
+				},
+				&db,
+			)
+			.await?;
+			client.redirect_uri_list =
+				format!("http://client{}.example.com/redirect/", i);
+			client.needs_grant = i % 2 == 0;
+			client.update(&db).await?;
+		}
+		println!("Seeded {} clients", self.clients_to_seed);
+		Ok(())
+	}
 
-    async fn seed_user(conn: &DbConn) {
-        todo!()
-    }
-}
+	async fn seed_users(self, bcrypt_cost: u32, db: &DbConn) -> Result<()> {
+		for i in 1..self.users_to_seed {
+			let new_user = NewUser {
+				username:  format!("user{}", i),
+				password:  random_token(12),
+				full_name: format!("Test user {}", i),
+				email:     format!("user{}@example.com", i),
+				ssh_key:   None,
+			};
+			if i % 2 == 0 {
+				User::create(new_user, bcrypt_cost, &db).await?;
+			} else {
+				User::create_pending(new_user, bcrypt_cost, &db).await?;
+			}
+		}
+		println!("Seeded {} users", self.users_to_seed);
+		Ok(())
+	}
 
-impl Fairing for Seeder {
-    fn info(&self) -> Info {
-        Info {
-            name: "Seed database",
-            kind: Kind::Liftoff,
-        }
-    }
+	async fn seed_admin(self, bcrypt_cost: u32, db: &DbConn) -> Result<()> {
+		let username = String::from("admin");
+		let password = self.admin_password.unwrap_or(String::from("admin"));
+		let admin = User::find_by_username(username.clone(), &db).await;
+		if admin.is_err() {
+			User::create(
+				NewUser {
+					username:  username.clone(),
+					password:  password.clone(),
+					full_name: String::from("Admin McAdmin"),
+					email:     String::from("admin@example.com"),
+					ssh_key:   None,
+				},
+				bcrypt_cost,
+				&db,
+			)
+			.await?;
+			println!(
+				"Seeded admin with username \"{}\" and password \"{}\"",
+				username, password
+			);
+		}
+		Ok(())
+	}
 
-    async fn on_liftoff(&self, rocket: &Rocket<Orbit>) {
-
-    }
+	async fn create_client(self, db: &DbConn) -> Result<()> {
+		let name = self.client_name.expect("client name");
+		let client = Client::find_by_name(name.clone(), &db).await;
+		if client.is_err() {
+			let mut client =
+				Client::create(NewClient { name: name.clone() }, &db).await?;
+			client.redirect_uri_list =
+				self.client_redirect_uri.unwrap_or(String::from(""));
+			client.update(&db).await?;
+			println!("Seeded client with name \"{}\"", name)
+		}
+		Ok(())
+	}
 }

--- a/src/ephemeral/authorization_token.rs
+++ b/src/ephemeral/authorization_token.rs
@@ -1,19 +1,20 @@
 use regex::Regex;
 use rocket::http::Status;
+use rocket::outcome::Outcome;
 use rocket::request::{self, FromRequest, Request};
-use rocket::Outcome;
 
 #[derive(Serialize)]
 pub struct AuthorizationToken {
 	username: String,
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for AuthorizationToken {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for AuthorizationToken {
 	type Error = String;
 
-	fn from_request(
-		request: &'a Request<'r>,
-	) -> request::Outcome<AuthorizationToken, String> {
+	async fn from_request(
+		request: &'r Request<'_>,
+	) -> request::Outcome<Self, Self::Error> {
 		let headers: Vec<_> = request.headers().get("Authorization").collect();
 		if headers.is_empty() {
 			let msg = String::from("Authorization header missing");

--- a/src/http_authentication.rs
+++ b/src/http_authentication.rs
@@ -1,7 +1,7 @@
 use rocket::http::Status;
 use rocket::request::{self, FromRequest, Request};
 
-use rocket::Outcome;
+use rocket::outcome::Outcome;
 use std::str::FromStr;
 
 #[derive(Debug)]
@@ -33,11 +33,12 @@ impl FromStr for BasicAuthentication {
 	}
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for BasicAuthentication {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for BasicAuthentication {
 	type Error = String;
 
-	fn from_request(
-		request: &'a Request<'r>,
+	async fn from_request(
+		request: &'r Request<'_>,
 	) -> request::Outcome<Self, Self::Error> {
 		let headers: Vec<_> = request.headers().get("Authorization").collect();
 		if headers.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,8 @@ extern crate toml;
 extern crate validator;
 
 #[macro_use]
-extern crate rocket_contrib;
-#[macro_use]
 extern crate rocket;
+extern crate rocket_sync_db_pools;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
@@ -36,20 +35,19 @@ pub mod mailer;
 pub mod models;
 pub mod token_store;
 pub mod util;
+// pub mod db_seed;
 
 use crate::config::Config;
 use crate::controllers::*;
 use crate::token_store::TokenStore;
-use rocket::Rocket;
-use rocket_contrib::serve::StaticFiles;
+use rocket::{Build, Rocket};
 
 use crate::mailer::Mailer;
-use diesel::PgConnection;
 use rocket::fairing::AdHoc;
-use std::convert::TryFrom;
+use rocket::fs::FileServer;
 
-// Embed diesel migrations (provides embedded_migrations::run())
-embed_migrations!();
+use rocket_sync_db_pools::database;
+use rocket_sync_db_pools::diesel::PgConnection;
 
 #[database("postgresql_database")]
 pub struct DbConn(PgConnection);
@@ -60,78 +58,81 @@ pub fn favicon() -> &'static str {
 	""
 }
 
-pub fn prepare_custom(config: rocket::Config) -> Rocket {
+pub fn prepare_custom(config: rocket::Config) -> Rocket<Build> {
 	assemble(rocket::custom(config))
 }
 
-pub fn prepare() -> Rocket {
-	assemble(rocket::ignite())
+pub fn prepare() -> Rocket<Build> {
+	assemble(rocket::build())
 }
 
 /// Setup of the given rocket instance. Mount routes, add managed state, and
 /// attach fairings.
-fn assemble(rocket: Rocket) -> Rocket {
-	let rocket_config = rocket.config();
-	let config: Config = Config::try_from(rocket_config).unwrap();
+fn assemble(rocket: Rocket<Build>) -> Rocket<Build> {
+	let config: Config = rocket.figment().extract().expect("config");
 	let token_store = TokenStore::<oauth_controller::UserToken>::new(&config);
 	let mailer = Mailer::new(&config).unwrap();
 
-	let mut rocket = rocket
+	let rocket = rocket
 		.mount(
 			"/",
 			routes![
 				favicon,
-				clients_controller::list_clients,
-				clients_controller::update_client_page,
-				clients_controller::update_client,
-				clients_controller::create_client,
-				clients_controller::delete_client,
-				oauth_controller::authorize,
-				oauth_controller::grant_get,
-				oauth_controller::grant_post,
-				oauth_controller::token,
-				pages_controller::home_page,
-				sessions_controller::create_session,
-				sessions_controller::new_session,
-				sessions_controller::delete_session,
-				sessions_controller::destroy_session,
-				users_controller::create_user_page,
-				users_controller::create_user,
-				users_controller::register_page,
-				users_controller::register,
-				users_controller::current_user,
-				users_controller::show_user,
-				users_controller::list_users,
-				users_controller::update_user,
-				users_controller::set_admin,
-				users_controller::set_approved,
-				users_controller::forgot_password_get,
-				users_controller::forgot_password_post,
-				users_controller::reset_password_get,
-				users_controller::reset_password_post,
+				/* clients_controller::list_clients,
+				 * clients_controller::update_client_page,
+				 * clients_controller::update_client,
+				 * clients_controller::create_client,
+				 * clients_controller::delete_client,
+				 * oauth_controller::authorize,
+				 * oauth_controller::grant_get,
+				 * oauth_controller::grant_post,
+				 * oauth_controller::token,
+				 * pages_controller::home_page,
+				 * sessions_controller::create_session,
+				 * sessions_controller::new_session,
+				 * sessions_controller::delete_session,
+				 * sessions_controller::destroy_session,
+				 * users_controller::create_user_page,
+				 * users_controller::create_user,
+				 * users_controller::register_page,
+				 * users_controller::register,
+				 * users_controller::current_user,
+				 * users_controller::show_user,
+				 * users_controller::list_users,
+				 * users_controller::update_user,
+				 * users_controller::set_admin,
+				 * users_controller::set_approved,
+				 * users_controller::forgot_password_get,
+				 * users_controller::forgot_password_post,
+				 * users_controller::reset_password_get,
+				 * users_controller::reset_password_post, */
 			],
 		)
-		.mount("/static/", StaticFiles::from("static/"))
+		.mount("/static/", FileServer::from("static/"))
 		.manage(token_store)
 		.manage(mailer)
 		.manage(config.clone())
 		.attach(DbConn::fairing())
-		.attach(AdHoc::on_attach("Database Migrations", run_migrations));
+		.attach(AdHoc::config::<Config>())
+		.attach(AdHoc::on_ignite("Database Migrations", run_migrations));
 
-	if rocket.config().environment.is_dev() {
-		rocket = util::seed_database(rocket, config);
-	}
+	// if rocket.config().environment.is_dev() {
+	// rocket = util::seed_database(rocket, config);
+	//}
 
 	rocket
 }
 
-fn run_migrations(rocket: Rocket) -> std::result::Result<Rocket, Rocket> {
-	let conn = DbConn::get_one(&rocket).expect("database connection");
-	match embedded_migrations::run(&*conn) {
-		Ok(()) => Ok(rocket),
-		Err(e) => {
-			eprintln!("Failed to run database migrations: {:?}", e);
-			Err(rocket)
-		},
-	}
+async fn run_migrations(rocket: Rocket<Build>) -> Rocket<Build> {
+	// This macro from `diesel_migrations` defines an `embedded_migrations`
+	// module containing a function named `run` that runs the migrations in the
+	// specified directory, initializing the database.
+	embed_migrations!("migrations");
+
+	let db = DbConn::get_one(&rocket).await.expect("database connection");
+	db.run(|conn| embedded_migrations::run(conn))
+		.await
+		.expect("diesel migrations");
+
+	rocket
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ use rocket::{Build, Rocket};
 
 use crate::mailer::Mailer;
 use rocket::fairing::AdHoc;
+use rocket::figment::Figment;
 use rocket::fs::FileServer;
 
 use rocket_sync_db_pools::database;
@@ -58,7 +59,7 @@ pub fn favicon() -> &'static str {
 	""
 }
 
-pub fn prepare_custom(config: rocket::Config) -> Rocket<Build> {
+pub fn prepare_custom(config: Figment) -> Rocket<Build> {
 	assemble(rocket::custom(config))
 }
 
@@ -78,40 +79,39 @@ fn assemble(rocket: Rocket<Build>) -> Rocket<Build> {
 			"/",
 			routes![
 				favicon,
-				/* clients_controller::list_clients,
-				 * clients_controller::update_client_page,
-				 * clients_controller::update_client,
-				 * clients_controller::create_client,
-				 * clients_controller::delete_client,
-				 * oauth_controller::authorize,
-				 * oauth_controller::grant_get,
-				 * oauth_controller::grant_post,
-				 * oauth_controller::token,
-				 * pages_controller::home_page,
-				 * sessions_controller::create_session,
-				 * sessions_controller::new_session,
-				 * sessions_controller::delete_session,
-				 * sessions_controller::destroy_session,
-				 * users_controller::create_user_page,
-				 * users_controller::create_user,
-				 * users_controller::register_page,
-				 * users_controller::register,
-				 * users_controller::current_user,
-				 * users_controller::show_user,
-				 * users_controller::list_users,
-				 * users_controller::update_user,
-				 * users_controller::set_admin,
-				 * users_controller::set_approved,
-				 * users_controller::forgot_password_get,
-				 * users_controller::forgot_password_post,
-				 * users_controller::reset_password_get,
-				 * users_controller::reset_password_post, */
+				clients_controller::list_clients,
+				clients_controller::update_client_page,
+				clients_controller::update_client,
+				clients_controller::create_client,
+				clients_controller::delete_client,
+				oauth_controller::authorize,
+				oauth_controller::grant_get,
+				oauth_controller::grant_post,
+				oauth_controller::token,
+				pages_controller::home_page,
+				sessions_controller::create_session,
+				sessions_controller::new_session,
+				sessions_controller::delete_session,
+				sessions_controller::destroy_session,
+				users_controller::create_user_page,
+				users_controller::create_user,
+				users_controller::register_page,
+				users_controller::register,
+				users_controller::current_user,
+				users_controller::show_user,
+				users_controller::list_users,
+				users_controller::update_user,
+				users_controller::set_admin,
+				users_controller::set_approved,
+				users_controller::forgot_password_get,
+				users_controller::forgot_password_post,
+				users_controller::reset_password_get,
+				users_controller::reset_password_post,
 			],
 		)
 		.mount("/static/", FileServer::from("static/"))
 		.manage(token_store)
 		.manage(mailer)
-		.manage(config.clone())
 		.attach(DbConn::fairing())
 		.attach(AdHoc::config::<Config>())
 		.attach(AdHoc::on_ignite("Database Migrations", run_migrations));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ extern crate validator_derive;
 pub mod views;
 pub mod config;
 pub mod controllers;
+pub mod db_seed;
 pub mod ephemeral;
 pub mod errors;
 pub mod http_authentication;
@@ -35,7 +36,6 @@ pub mod mailer;
 pub mod models;
 pub mod token_store;
 pub mod util;
-// pub mod db_seed;
 
 use crate::config::Config;
 use crate::controllers::*;

--- a/src/mailer.rs
+++ b/src/mailer.rs
@@ -65,10 +65,11 @@ impl Mailer {
 		let wait = Duration::from_secs(config.mail_queue_wait_seconds);
 		let (sender, recv) = mpsc::sync_channel(config.mail_queue_size);
 
-		match config.mail_server {
-			"stub" => thread::spawn(Self::stub_sender(wait, recv)),
-			server => thread::spawn(Self::smtp_sender(wait, recv, server)?),
-		};
+		if config.mail_server == "stub" {
+			thread::spawn(Self::stub_sender(wait, recv));
+		} else {
+			thread::spawn(Self::smtp_sender(wait, recv, &config.mail_server)?);
+		}
 
 		Ok(Mailer {
 			from:  config

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
+#[macro_use]
+extern crate rocket;
 extern crate zauth;
 
-fn main() {
-	zauth::prepare().launch();
+#[launch]
+fn zauth() -> _ {
+	zauth::prepare()
 }

--- a/src/models/client.rs
+++ b/src/models/client.rs
@@ -1,7 +1,7 @@
 use diesel::{self, prelude::*};
 
 use crate::errors::{AuthenticationError, Result, ZauthError};
-use crate::ConcreteConnection;
+use crate::DbConn;
 
 use self::schema::clients;
 
@@ -58,8 +58,10 @@ pub struct ClientChange {
 }
 
 impl Client {
-	pub fn all(conn: &ConcreteConnection) -> Result<Vec<Client>> {
-		let all_clients = clients::table.load::<Client>(conn)?;
+	pub async fn all(db: &DbConn) -> Result<Vec<Client>> {
+		let all_clients = db
+			.run(move |conn| clients::table.load::<Client>(conn))
+			.await?;
 		Ok(all_clients)
 	}
 
@@ -67,17 +69,14 @@ impl Client {
 		random_token(SECRET_LENGTH)
 	}
 
-	pub fn create(
-		client: NewClient,
-		conn: &ConcreteConnection,
-	) -> Result<Client> {
+	pub async fn create(client: NewClient, db: &DbConn) -> Result<Client> {
 		client.validate()?;
 		let client = NewClientWithSecret {
 			name:   client.name,
 			secret: Self::generate_random_secret(),
 		};
-		let client = conn
-			.transaction(|| {
+		db.run(move |conn| {
+			conn.transaction(|| {
 				// Create a new client
 				diesel::insert_into(clients::table)
 					.values(&client)
@@ -85,8 +84,9 @@ impl Client {
 				// Fetch the last created client
 				clients::table.order(clients::id.desc()).first(conn)
 			})
-			.map_err(ZauthError::from);
-		return client;
+			.map_err(ZauthError::from)
+		})
+		.await
 	}
 
 	pub fn change_with(&mut self, change: ClientChange) -> Result<()> {
@@ -105,37 +105,44 @@ impl Client {
 		Ok(())
 	}
 
-	pub fn update(self, conn: &ConcreteConnection) -> Result<Self> {
+	pub async fn update(self, db: &DbConn) -> Result<Self> {
 		let id = self.id;
+		db.run(move |conn| {
+			conn.transaction(|| {
+				// Update a client
+				diesel::update(clients::table.find(id))
+					.set(self)
+					.execute(conn)?;
 
-		conn.transaction(|| {
-			// Update a client
-			diesel::update(clients::table.find(id))
-				.set(self)
-				.execute(conn)?;
-
-			// Fetch the updated record
-			clients::table.find(id).first(conn)
+				// Fetch the updated record
+				clients::table.find(id).first(conn)
+			})
+			.map_err(ZauthError::from)
 		})
-		.map_err(ZauthError::from)
+		.await
 	}
 
-	pub fn delete(self, conn: &ConcreteConnection) -> Result<()> {
-		diesel::delete(clients::table.find(self.id)).execute(conn)?;
+	pub async fn delete(self, db: &DbConn) -> Result<()> {
+		db.run(move |conn| {
+			diesel::delete(clients::table.find(self.id)).execute(conn)
+		})
+		.await?;
 		Ok(())
 	}
 
-	pub fn find_by_name(
-		name: &str,
-		conn: &ConcreteConnection,
-	) -> Result<Client> {
-		let client =
-			clients::table.filter(clients::name.eq(name)).first(conn)?;
+	pub async fn find_by_name(name: String, db: &DbConn) -> Result<Client> {
+		let client = db
+			.run(move |conn| {
+				clients::table.filter(clients::name.eq(name)).first(conn)
+			})
+			.await?;
 		Ok(client)
 	}
 
-	pub fn find(id: i32, conn: &ConcreteConnection) -> Result<Client> {
-		let client = clients::table.find(id).first(conn)?;
+	pub async fn find(id: i32, db: &DbConn) -> Result<Client> {
+		let client = db
+			.run(move |conn| clients::table.find(id).first(conn))
+			.await?;
 		Ok(client)
 	}
 
@@ -145,12 +152,12 @@ impl Client {
 			.any(|uri| uri == redirect_uri)
 	}
 
-	pub fn find_and_authenticate(
-		name: &str,
+	pub async fn find_and_authenticate(
+		name: String,
 		secret: &str,
-		conn: &ConcreteConnection,
+		db: &DbConn,
 	) -> Result<Client> {
-		let client = Self::find_by_name(name, conn)?;
+		let client = Self::find_by_name(name, db).await?;
 		if client.secret == secret {
 			Ok(client)
 		} else {

--- a/src/models/client.rs
+++ b/src/models/client.rs
@@ -11,7 +11,7 @@ use validator::Validate;
 
 const SECRET_LENGTH: usize = 64;
 
-mod schema {
+pub mod schema {
 	table! {
 		clients {
 			id -> Integer,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -37,7 +37,7 @@ impl fmt::Display for UserState {
 	}
 }
 
-mod schema {
+pub mod schema {
 	table! {
 		use diesel::sql_types::*;
 		use crate::models::user::UserStateMapping;

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,222 +11,221 @@ pub fn random_token(token_length: usize) -> String {
 		.collect()
 }
 
-pub use dev::seed_database;
-
-mod dev {
-	use crate::config::Config;
-	use crate::models::client::*;
-	use crate::models::user::*;
-	use crate::DbConn;
-	use rocket::fairing::AdHoc;
-	use rocket::Rocket;
-
-	pub fn seed_database(mut rocket: Rocket, config: Config) -> Rocket {
-		assert!(rocket.config().environment.is_dev());
-		if let Ok(_) = std::env::var("ZAUTH_EMPTY_DB") {
-			rocket = rocket
-				.attach(AdHoc::on_attach("Empty database", |rocket| {
-					delete_all(rocket)
-				}));
-		}
-
-		if let Ok(number) = std::env::var("ZAUTH_SEED_CLIENT") {
-			let amount = number.parse().unwrap_or_else(|_e| {
-				eprintln!(
-					"ZAUTH_SEED_DB=\"{}\" error, expected number, defaulting \
-					 to 10",
-					number
-				);
-				10
-			});
-			rocket = rocket
-				.attach(AdHoc::on_attach("Seed clients", move |rocket| {
-					seed_clients(rocket, amount)
-				}));
-		}
-
-		if let Ok(number) = std::env::var("ZAUTH_SEED_USER") {
-			let config_copy = config.clone();
-			let amount = number.parse().unwrap_or_else(|_e| {
-				eprintln!(
-					"ZAUTH_SEED_USER=\"{}\" error, expected number, \
-					 defaulting to 10",
-					number
-				);
-				10
-			});
-			rocket = rocket
-				.attach(AdHoc::on_attach("Seed users", move |rocket| {
-					seed_users(rocket, config_copy, amount)
-				}));
-		}
-
-		if let Ok(pw) = std::env::var("ZAUTH_ADMIN_PASSWORD") {
-			let config_copy = config.clone();
-
-			rocket = rocket
-				.attach(AdHoc::on_attach("Create admin user", |rocket| {
-					create_admin(rocket, config_copy, pw)
-				}));
-		}
-
-		if let Ok(client) = std::env::var("ZAUTH_CLIENT_NAME") {
-			rocket = rocket
-				.attach(AdHoc::on_attach("Create admin user", |rocket| {
-					create_client(rocket, client)
-				}));
-		}
-
-		rocket
-	}
-
-	fn create_admin(
-		rocket: Rocket,
-		config: Config,
-		password: String,
-	) -> std::result::Result<Rocket, Rocket> {
-		let username = String::from("admin");
-		let conn = DbConn::get_one(&rocket).expect("database connection");
-		let admin = User::find_by_username(&username, &conn)
-			.or_else(|_e| {
-				User::create(
-					NewUser {
-						username:  username.clone(),
-						password:  password.clone(),
-						full_name: String::from("Admin McAdmin"),
-						email:     String::from("admin@example.com"),
-						ssh_key:   None,
-					},
-					config.bcrypt_cost,
-					&conn,
-				)
-			})
-			.and_then(|mut user| {
-				user.admin = true;
-				user.update(&conn)
-			});
-		match admin {
-			Ok(_admin) => {
-				println!(
-					"Admin created with username \"{}\" and password \"{}\"",
-					username, password
-				);
-				Ok(rocket)
-			},
-			Err(e) => {
-				eprintln!("Error creating admin {:?}", e);
-				Err(rocket)
-			},
-		}
-	}
-
-	fn create_client(
-		rocket: Rocket,
-		name: String,
-	) -> std::result::Result<Rocket, Rocket> {
-		let conn = DbConn::get_one(&rocket).expect("database connection");
-		let client = Client::find_by_name(&name, &conn).or_else(|_e| {
-			let mut new_client = Client::create(NewClient { name }, &conn)?;
-			new_client.needs_grant = true;
-			new_client.redirect_uri_list =
-				String::from("http://localhost:8000/trueclient/home");
-			new_client.update(&conn)
-		});
-
-		match client {
-			Ok(client) => {
-				println!(
-					"Created client \"{}\" with secrect \"{}\"",
-					client.name, client.secret
-				);
-				Ok(rocket)
-			},
-			Err(e) => {
-				eprintln!("Error creating client {:?}", e);
-				Err(rocket)
-			},
-		}
-	}
-
-	fn seed_users(
-		rocket: Rocket,
-		config: Config,
-		amount: usize,
-	) -> std::result::Result<Rocket, Rocket> {
-		let conn = DbConn::get_one(&rocket).expect("database connection");
-		for i in 0..amount {
-			let name = format!("seeded_user_{}", i);
-			let f = if i < amount / 2 {
-				User::create
-			} else {
-				User::create_pending
-			};
-			if let Err(e) = f(
-				NewUser {
-					username:  name.clone(),
-					password:  super::random_token(12),
-					full_name: format!("Example {}", i),
-					email:     format!("{}@example.com", name),
-					ssh_key:   None,
-				},
-				config.bcrypt_cost,
-				&conn,
-			) {
-				eprintln!("Error creating user {:?}", e);
-				break;
-			}
-		}
-
-		Ok(rocket)
-	}
-
-	fn seed_clients(
-		rocket: Rocket,
-		amount: usize,
-	) -> std::result::Result<Rocket, Rocket> {
-		let conn = DbConn::get_one(&rocket).expect("database connection");
-
-		for i in 0..amount {
-			let name = format!("seeded_client_{}", i);
-			if let Err(e) = Client::find_by_name(&name, &conn).or_else(|_e| {
-				let mut new_client = Client::create(NewClient { name }, &conn)?;
-				new_client.needs_grant = i < amount / 2;
-				new_client.redirect_uri_list =
-					format!("http://localhost:{}/trueclient/home", 8000 + i);
-				new_client.update(&conn)
-			}) {
-				eprintln!("Error creating client {:?}", e);
-				break;
-			}
-		}
-
-		Ok(rocket)
-	}
-
-	fn delete_all(rocket: Rocket) -> std::result::Result<Rocket, Rocket> {
-		use crate::models::client::*;
-
-		let conn = DbConn::get_one(&rocket).expect("database connection");
-		let delete_users = User::all(&conn).and_then(|users| {
-			users
-				.into_iter()
-				.map(|u| User::delete(u, &conn))
-				.fold(Ok(()), Result::and)
-		});
-		if let Err(e) = delete_users {
-			eprintln!("Failed deleting users. {:?}", e);
-		}
-
-		let delete_clients = Client::all(&conn).and_then(|users| {
-			users
-				.into_iter()
-				.map(|c| Client::delete(c, &conn))
-				.fold(Ok(()), Result::and)
-		});
-		if let Err(e) = delete_clients {
-			eprintln!("Failed deleting clients. {:?}", e);
-		}
-
-		Ok(rocket)
-	}
-}
+// pub use dev::seed_database;
+//
+// mod dev {
+// use crate::config::Config;
+// use crate::models::client::*;
+// use crate::models::user::*;
+// use crate::DbConn;
+// use rocket::fairing::AdHoc;
+// use rocket::{Build, Ignite, Rocket};
+//
+// pub fn seed_database(
+// mut rocket: Rocket<Ignite>,
+// ) -> Rocket<Ignite> {
+// assert!(rocket.config().profile.starts_with("dev"));
+//
+// let conn = DbConn::get_one(&rocket).expect("database connection");
+//
+// if let Ok(_) = std::env::var("ZAUTH_EMPTY_DB") {
+// delete_all(&conn)
+// }
+//
+// if let Ok(number) = std::env::var("ZAUTH_SEED_CLIENT") {
+// let amount = number.parse().unwrap_or_else(|_e| {
+// eprintln!(
+// "ZAUTH_SEED_DB=\"{}\" error, expected number, defaulting \
+// to 10",
+// number
+// );
+// 10
+// });
+// seed_clients(rocket, amount)
+// }
+//
+// if let Ok(number) = std::env::var("ZAUTH_SEED_USER") {
+// let config_copy = config.clone();
+// let amount = number.parse().unwrap_or_else(|_e| {
+// eprintln!(
+// "ZAUTH_SEED_USER=\"{}\" error, expected number, \
+// defaulting to 10",
+// number
+// );
+// 10
+// });
+//
+// seed_users(&rocket, config_copy, amount)
+// }
+//
+// if let Ok(pw) = std::env::var("ZAUTH_ADMIN_PASSWORD") {
+// let config_copy = config.clone();
+//
+// rocket = rocket
+// .attach(AdHoc::on_attach("Create admin user", |rocket| {
+// create_admin(rocket, config_copy, pw)
+// }));
+// }
+//
+// if let Ok(client) = std::env::var("ZAUTH_CLIENT_NAME") {
+// rocket = rocket
+// .attach(AdHoc::on_attach("Create admin user", |rocket| {
+// create_client(rocket, client)
+// }));
+// }
+//
+// rocket
+// }
+//
+// fn create_admin(
+// rocket: Rocket<Ignite>,
+// config: Config,
+// password: String,
+// ) -> std::result::Result<Rocket<Ignite>, Rocket<Ignite>> {
+// let username = String::from("admin");
+// let conn = DbConn::get_one(&rocket).expect("database connection");
+// let admin = User::find_by_username(&username, &conn)
+// .or_else(|_e| {
+// User::create(
+// NewUser {
+// username:  username.clone(),
+// password:  password.clone(),
+// full_name: String::from("Admin McAdmin"),
+// email:     String::from("admin@example.com"),
+// ssh_key:   None,
+// },
+// config.bcrypt_cost,
+// &conn,
+// )
+// })
+// .and_then(|mut user| {
+// user.admin = true;
+// user.update(&conn)
+// });
+// match admin {
+// Ok(_admin) => {
+// println!(
+// "Admin created with username \"{}\" and password \"{}\"",
+// username, password
+// );
+// Ok(rocket)
+// },
+// Err(e) => {
+// eprintln!("Error creating admin {:?}", e);
+// Err(rocket)
+// },
+// }
+// }
+//
+// fn create_client(
+// rocket: Rocket<Ignite>,
+// name: String,
+// ) -> std::result::Result<Rocket<Ignite>, Rocket<Ignite>> {
+// let conn = DbConn::get_one(&rocket).expect("database connection");
+// let client = Client::find_by_name(&name, &conn).or_else(|_e| {
+// let mut new_client = Client::create(NewClient { name }, &conn)?;
+// new_client.needs_grant = true;
+// new_client.redirect_uri_list =
+// String::from("http://localhost:8000/trueclient/home");
+// new_client.update(&conn)
+// });
+//
+// match client {
+// Ok(client) => {
+// println!(
+// "Created client \"{}\" with secrect \"{}\"",
+// client.name, client.secret
+// );
+// Ok(rocket)
+// },
+// Err(e) => {
+// eprintln!("Error creating client {:?}", e);
+// Err(rocket)
+// },
+// }
+// }
+//
+// fn seed_users(
+// rocket: Rocket<Ignite>,
+// config: Config,
+// amount: usize,
+// ) -> std::result::Result<Rocket<Ignite>, Rocket<Ignite>> {
+// let conn = DbConn::get_one(&rocket).expect("database connection");
+// for i in 0..amount {
+// let name = format!("seeded_user_{}", i);
+// let f = if i < amount / 2 {
+// User::create
+// } else {
+// User::create_pending
+// };
+// if let Err(e) = f(
+// NewUser {
+// username:  name.clone(),
+// password:  super::random_token(12),
+// full_name: format!("Example {}", i),
+// email:     format!("{}@example.com", name),
+// ssh_key:   None,
+// },
+// config.bcrypt_cost,
+// &conn,
+// ) {
+// eprintln!("Error creating user {:?}", e);
+// break;
+// }
+// }
+//
+// Ok(rocket)
+// }
+//
+// async fn seed_clients(
+// rocket: Rocket<Ignite>,
+// amount: usize,
+// ) -> std::result::Result<Rocket<Ignite>, Rocket<Ignite>> {
+// let conn = DbConn::get_one(&rocket).await.expect("database connection");
+//
+// for i in 0..amount {
+// let name = format!("seeded_client_{}", i);
+// if let Err(e) = Client::find_by_name(&name, &conn).or_else(|_e| {
+// let mut new_client = Client::create(NewClient { name }, &conn)?;
+// new_client.needs_grant = i < amount / 2;
+// new_client.redirect_uri_list =
+// format!("http://localhost:{}/trueclient/home", 8000 + i);
+// new_client.update(&conn)
+// }) {
+// eprintln!("Error creating client {:?}", e);
+// break;
+// }
+// }
+//
+// Ok(rocket)
+// }
+//
+// fn delete_all(
+// rocket: Rocket<Ignite>,
+// ) -> std::result::Result<Rocket<Ignite>, Rocket<Ignite>> {
+// use crate::models::client::*;
+//
+// let conn = DbConn::get_one(&rocket).expect("database connection");
+// let delete_users = User::all(&conn).and_then(|users| {
+// users
+// .into_iter()
+// .map(|u| User::delete(u, &conn))
+// .fold(Ok(()), Result::and)
+// });
+// if let Err(e) = delete_users {
+// eprintln!("Failed deleting users. {:?}", e);
+// }
+//
+// let delete_clients = Client::all(&conn).and_then(|users| {
+// users
+// .into_iter()
+// .map(|c| Client::delete(c, &conn))
+// .fold(Ok(()), Result::and)
+// });
+// if let Err(e) = delete_clients {
+// eprintln!("Failed deleting clients. {:?}", e);
+// }
+//
+// Ok(rocket)
+// }
+// }

--- a/src/views/accepter.rs
+++ b/src/views/accepter.rs
@@ -63,7 +63,9 @@ where
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 mod test {
+
 	use super::*;
 	use rocket::http::{Accept, Header, Status};
 	use rocket::local::blocking::Client;
@@ -99,8 +101,7 @@ mod test {
 	#[test]
 	fn accept_html() {
 		let client = client();
-		let mut response =
-			client.get("/simple").header(Accept::HTML).dispatch();
+		let response = client.get("/simple").header(Accept::HTML).dispatch();
 		assert_eq!(response.status(), Status::Ok);
 		assert_eq!(
 			response.headers().get("content-type").next(),
@@ -115,8 +116,7 @@ mod test {
 	#[test]
 	fn accept_json() {
 		let client = client();
-		let mut response =
-			client.get("/simple").header(Accept::JSON).dispatch();
+		let response = client.get("/simple").header(Accept::JSON).dispatch();
 		assert_eq!(response.status(), Status::Ok);
 		assert_eq!(
 			response.headers().get("content-type").next(),
@@ -145,7 +145,7 @@ mod test {
 	#[test]
 	fn prefers_html() {
 		let client = client();
-		let mut response = client
+		let response = client
 			.get("/simple")
 			.header(Header::new(
 				"Accept",
@@ -167,7 +167,7 @@ mod test {
 	#[test]
 	fn prefers_json() {
 		let client = client();
-		let mut response = client
+		let response = client
 			.get("/simple")
 			.header(Header::new(
 				"Accept",

--- a/tests/clients.rs
+++ b/tests/clients.rs
@@ -1,3 +1,5 @@
+#![feature(async_closure)]
+
 extern crate diesel;
 extern crate rocket;
 
@@ -9,11 +11,10 @@ mod common;
 
 use crate::common::url;
 
-#[test]
-fn create_and_update_client() {
-	common::as_admin(|http_client, _db, _user| {
+#[rocket::async_test]
+async fn create_and_update_client() {
+	common::as_admin(async move |http_client, _db, _user| {
 		let client_name = "test";
-		let client_redirect_uri = "https://example.com/redirect";
 
 		let client_form = format!("name={}", url(&client_name),);
 
@@ -22,8 +23,10 @@ fn create_and_update_client() {
 			.body(client_form)
 			.header(ContentType::Form)
 			.header(Accept::JSON)
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(response.status(), Status::Created);
-	});
+	})
+	.await;
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,21 +10,19 @@ extern crate zauth;
 use diesel::sql_query;
 use diesel::RunQueryDsl;
 use parking_lot::Mutex;
-use rocket::config::{Config, Value};
-use rocket::http::ContentType;
-use rocket::http::Status;
-use std::collections::HashMap;
 use std::str::FromStr;
 
 use crate::common::zauth::models::client::*;
 use crate::common::zauth::models::user::*;
 use crate::common::zauth::DbConn;
 use lettre::Address;
+use rocket::http::{ContentType, Status};
+use std::future::Future;
 use std::thread;
 use std::time::Duration;
 use zauth::mailer::STUB_MAILER_OUTBOX;
 
-type HttpClient = rocket::local::Client;
+type HttpClient = rocket::local::asynchronous::Client;
 
 // Rocket doesn't support transactional testing yet, so we use a lock to
 // serialize tests.
@@ -36,9 +34,12 @@ pub fn url(content: &str) -> String {
 	urlencoding::encode(content)
 }
 
-fn reset_db(db: &DbConn) {
-	assert!(sql_query("TRUNCATE TABLE users").execute(&db.0).is_ok());
-	assert!(sql_query("TRUNCATE TABLE clients").execute(&db.0).is_ok());
+async fn reset_db(db: &DbConn) {
+	db.run(|conn| {
+		assert!(sql_query("TRUNCATE TABLE users").execute(conn).is_ok());
+		assert!(sql_query("TRUNCATE TABLE clients").execute(conn).is_ok());
+	})
+	.await
 }
 
 /// Creates a rocket::local::Client for testing purposes. The rocket instance
@@ -46,33 +47,37 @@ fn reset_db(db: &DbConn) {
 /// executes the given function with the Client a connection to that
 /// database. The database and its directory will be removed after the function
 /// has run.
-pub fn as_visitor<F>(run: F)
-where F: FnOnce(HttpClient, DbConn) -> () {
+pub async fn as_visitor<F, R>(run: F)
+where
+	F: FnOnce(HttpClient, DbConn) -> R,
+	R: Future<Output = ()>,
+{
 	// Prepare config
-	let mut cfg = HashMap::new();
 	let db_url = "postgresql://zauth:zauth@localhost/zauth_test";
-	let cfg_str = format!("postgresql_database = {{ url = \"{}\" }}", db_url);
-	let databases: Value = Value::from_str(&cfg_str).unwrap();
-	cfg.insert("databases".into(), databases);
-	cfg.insert("template_dir".into(), "src/views/".into());
-	let mut config = Config::development();
-	config.set_extras(cfg);
+	let config = rocket::Config::figment()
+		.merge(("databases.postgresql_database.url", db_url));
 
 	let _lock = DB_LOCK.lock();
-	let client =
-		HttpClient::new(zauth::prepare_custom(config)).expect("rocket client");
+	let client = HttpClient::tracked(zauth::prepare_custom(config))
+		.await
+		.expect("rocket client");
 
-	let db = DbConn::get_one(client.rocket()).expect("database connection");
-	reset_db(&db);
-	assert_eq!(0, User::all(&db).unwrap().len());
-	assert_eq!(0, Client::all(&db).unwrap().len());
+	let db = DbConn::get_one(client.rocket())
+		.await
+		.expect("database connection");
+	reset_db(&db).await;
+	assert_eq!(0, User::all(&db).await.unwrap().len());
+	assert_eq!(0, Client::all(&db).await.unwrap().len());
 
-	run(client, db);
+	run(client, db).await;
 }
 
-pub fn as_user<F>(run: F)
-where F: FnOnce(HttpClient, DbConn, User) -> () {
-	as_visitor(|client, db| {
+pub async fn as_user<F, R>(run: F)
+where
+	F: FnOnce(HttpClient, DbConn, User) -> R,
+	R: Future<Output = ()>,
+{
+	as_visitor(async move |client, db| {
 		let user = User::create(
 			NewUser {
 				username:  String::from("username"),
@@ -84,6 +89,7 @@ where F: FnOnce(HttpClient, DbConn, User) -> () {
 			BCRYPT_COST,
 			&db,
 		)
+		.await
 		.unwrap();
 
 		{
@@ -91,17 +97,22 @@ where F: FnOnce(HttpClient, DbConn, User) -> () {
 				.post("/login")
 				.body("username=username&password=password")
 				.header(ContentType::Form)
-				.dispatch();
+				.dispatch()
+				.await;
 			assert_eq!(response.status(), Status::SeeOther, "login failed");
 		}
 
-		run(client, db, user);
-	});
+		run(client, db, user).await;
+	})
+	.await;
 }
 
-pub fn as_admin<F>(run: F)
-where F: FnOnce(HttpClient, DbConn, User) -> () {
-	as_visitor(|client, db| {
+pub async fn as_admin<F, R>(run: F)
+where
+	F: FnOnce(HttpClient, DbConn, User) -> R,
+	R: Future<Output = ()>,
+{
+	as_visitor(async move |client, db| {
 		let mut user = User::create(
 			NewUser {
 				username:  String::from("admin"),
@@ -113,28 +124,35 @@ where F: FnOnce(HttpClient, DbConn, User) -> () {
 			BCRYPT_COST,
 			&db,
 		)
+		.await
 		.unwrap();
 
 		user.admin = true;
-		let user = user.update(&db).unwrap();
+		let user = user.update(&db).await.unwrap();
 
 		{
 			let response = client
 				.post("/login")
 				.body("username=admin&password=password")
 				.header(ContentType::Form)
-				.dispatch();
+				.dispatch()
+				.await;
 			assert_eq!(response.status(), Status::SeeOther, "login failed");
 		}
 
-		run(client, db, user);
-	});
+		run(client, db, user).await;
+	})
+	.await;
 }
 
-pub fn dont_expect_mail<T>(run: impl FnOnce() -> T) -> T {
+pub async fn dont_expect_mail<T, F, R>(run: F) -> T
+where
+	F: FnOnce() -> R,
+	R: Future<Output = T>,
+{
 	let (mailbox, _condvar) = &STUB_MAILER_OUTBOX;
 	let outbox_size = { mailbox.lock().len() };
-	let result: T = run();
+	let result: T = run().await;
 	thread::sleep(Duration::from_secs(1));
 	assert_eq!(
 		outbox_size,
@@ -144,10 +162,14 @@ pub fn dont_expect_mail<T>(run: impl FnOnce() -> T) -> T {
 	result
 }
 
-pub fn expect_mail_to<T>(receivers: Vec<&str>, run: impl FnOnce() -> T) -> T {
+pub async fn expect_mail_to<T, F, R>(receivers: Vec<&str>, run: F) -> T
+where
+	F: FnOnce() -> R,
+	R: Future<Output = T>,
+{
 	let (mailbox, condvar) = &STUB_MAILER_OUTBOX;
 	let outbox_size = { mailbox.lock().len() };
-	let result: T = run();
+	let result: T = run().await;
 
 	let mut mailbox = mailbox.lock();
 	if mailbox.len() == outbox_size {

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,3 +1,5 @@
+#![feature(async_closure)]
+
 extern crate diesel;
 extern crate rocket;
 
@@ -8,40 +10,44 @@ use zauth::models::user::*;
 
 mod common;
 
-#[test]
-fn get_all_users() {
-	common::as_visitor(|http_client, _db| {
-		let response = http_client.get("/users").dispatch();
+#[rocket::async_test]
+async fn get_all_users() {
+	common::as_visitor(async move |http_client, _db| {
+		let response = http_client.get("/users").dispatch().await;
 		assert_eq!(response.status(), Status::Unauthorized);
-	});
+	})
+	.await;
 
-	common::as_user(|http_client, _db, _user| {
-		let response = http_client.get("/users").dispatch();
+	common::as_user(async move |http_client, _db, _user| {
+		let response = http_client.get("/users").dispatch().await;
 		assert_eq!(response.status(), Status::Forbidden);
-	});
+	})
+	.await;
 
-	common::as_admin(|http_client, _db, _admin| {
-		let response = http_client.get("/users").dispatch();
+	common::as_admin(async move |http_client, _db, _admin| {
+		let response = http_client.get("/users").dispatch().await;
 
 		assert_eq!(response.status(), Status::Ok);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn show_user_as_visitor() {
-	common::as_visitor(|http_client, _db| {
-		let response = http_client.get("/users/1").dispatch();
+#[rocket::async_test]
+async fn show_user_as_visitor() {
+	common::as_visitor(async move |http_client, _db| {
+		let response = http_client.get("/users/1").dispatch().await;
 		assert_eq!(
 			response.status(),
 			Status::Unauthorized,
 			"visitor should get unauthrorized"
 		);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn show_user_as_user() {
-	common::as_user(|http_client, db, user| {
+#[rocket::async_test]
+async fn show_user_as_user() {
+	common::as_user(async move |http_client, db, user| {
 		let other = User::create(
 			NewUser {
 				username:  String::from("somebody"),
@@ -53,10 +59,13 @@ fn show_user_as_user() {
 			common::BCRYPT_COST,
 			&db,
 		)
+		.await
 		.unwrap();
 
-		let response =
-			http_client.get(format!("/users/{}", other.id)).dispatch();
+		let response = http_client
+			.get(format!("/users/{}", other.id))
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
@@ -64,20 +73,23 @@ fn show_user_as_user() {
 			"should not be able to see other user's profile"
 		);
 
-		let response =
-			http_client.get(format!("/users/{}", user.id)).dispatch();
+		let response = http_client
+			.get(format!("/users/{}", user.id))
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
 			Status::Ok,
 			"should be able to see own profile"
 		);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn show_user_as_admin() {
-	common::as_admin(|http_client, db, admin| {
+#[rocket::async_test]
+async fn show_user_as_admin() {
+	common::as_admin(async move |http_client, db, admin| {
 		let other = User::create(
 			NewUser {
 				username:  String::from("somebody"),
@@ -89,10 +101,13 @@ fn show_user_as_admin() {
 			common::BCRYPT_COST,
 			&db,
 		)
+		.await
 		.unwrap();
 
-		let response =
-			http_client.get(format!("/users/{}", other.id)).dispatch();
+		let response = http_client
+			.get(format!("/users/{}", other.id))
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
@@ -100,26 +115,30 @@ fn show_user_as_admin() {
 			"admin should see other's profile"
 		);
 
-		let response =
-			http_client.get(format!("/users/{}", admin.id)).dispatch();
+		let response = http_client
+			.get(format!("/users/{}", admin.id))
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
 			Status::Ok,
 			"admin should see own profile"
 		);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn update_self() {
-	common::as_user(|http_client, db, user| {
+#[rocket::async_test]
+async fn update_self() {
+	common::as_user(async move |http_client, db, user| {
 		let response = http_client
 			.put(format!("/users/{}", user.id))
 			.header(ContentType::Form)
 			.header(Accept::JSON)
 			.body("username=newusername")
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
@@ -127,7 +146,7 @@ fn update_self() {
 			"user should be able to edit themself"
 		);
 
-		let updated = User::find(user.id, &db).unwrap();
+		let updated = User::find(user.id, &db).await.unwrap();
 
 		assert_eq!("newusername", updated.username);
 
@@ -142,6 +161,7 @@ fn update_self() {
 			common::BCRYPT_COST,
 			&db,
 		)
+		.await
 		.unwrap();
 
 		let response = http_client
@@ -149,25 +169,28 @@ fn update_self() {
 			.header(ContentType::Form)
 			.header(Accept::JSON)
 			.body("username=newusername")
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
 			Status::Forbidden,
 			"user should not be able to edit others"
 		);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn change_password() {
-	common::as_user(|http_client, db, user| {
+#[rocket::async_test]
+async fn change_password() {
+	common::as_user(async move |http_client, db, user| {
 		let response = http_client
 			.put(format!("/users/{}", user.id))
 			.header(ContentType::Form)
 			.header(Accept::JSON)
 			.body("password=newpassword")
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
@@ -175,18 +198,19 @@ fn change_password() {
 			"user should be able to change password"
 		);
 
-		let updated = User::find(user.id, &db).unwrap();
+		let updated = User::find(user.id, &db).await.unwrap();
 
 		assert_ne!(
 			user.hashed_password, updated.hashed_password,
 			"password should have changed"
 		);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn make_admin() {
-	common::as_admin(|http_client, db, _admin| {
+#[rocket::async_test]
+async fn make_admin() {
+	common::as_admin(async move |http_client, db, _admin| {
 		let other = User::create(
 			NewUser {
 				username:  String::from("somebody"),
@@ -198,6 +222,7 @@ fn make_admin() {
 			common::BCRYPT_COST,
 			&db,
 		)
+		.await
 		.unwrap();
 
 		let response = http_client
@@ -205,7 +230,8 @@ fn make_admin() {
 			.header(ContentType::Form)
 			.header(Accept::JSON)
 			.body("admin=true")
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
@@ -213,15 +239,16 @@ fn make_admin() {
 			"admin should be able to make other admin"
 		);
 
-		let updated = User::find(other.id, &db).unwrap();
+		let updated = User::find(other.id, &db).await.unwrap();
 
 		assert!(updated.admin, "other user should be admin now");
-	});
+	})
+	.await;
 }
 
-#[test]
-fn try_make_admin() {
-	common::as_user(|http_client, db, _user| {
+#[rocket::async_test]
+async fn try_make_admin() {
+	common::as_user(async move |http_client, db, _user| {
 		let other = User::create(
 			NewUser {
 				username:  String::from("somebody"),
@@ -233,6 +260,7 @@ fn try_make_admin() {
 			common::BCRYPT_COST,
 			&db,
 		)
+		.await
 		.unwrap();
 
 		let response = http_client
@@ -240,20 +268,22 @@ fn try_make_admin() {
 			.header(ContentType::Form)
 			.header(Accept::JSON)
 			.body("admin=true")
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
 			Status::Forbidden,
 			"user should not be able to make other admin"
 		);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn create_user_form() {
-	common::as_admin(|http_client, db, _admin| {
-		let user_count = User::all(&db).unwrap().len();
+#[rocket::async_test]
+async fn create_user_form() {
+	common::as_admin(async move |http_client, db, _admin| {
+		let user_count = User::all(&db).await.unwrap().len();
 
 		let response = http_client
 			.post("/users")
@@ -264,21 +294,23 @@ fn create_user_form() {
 				 email=hij@klm.op&ssh_key=ssh-rsa%20base64%3D%3D%20user@\
 				 hostname",
 			)
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(response.status(), Status::Ok);
 
-		assert_eq!(user_count + 1, User::all(&db).unwrap().len());
+		assert_eq!(user_count + 1, User::all(&db).await.unwrap().len());
 
-		let last_created = User::last(&db).unwrap();
+		let last_created = User::last(&db).await.unwrap();
 		assert_eq!("testuser", last_created.username);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn create_user_json() {
-	common::as_admin(|http_client, db, _admin| {
-		let user_count = User::all(&db).unwrap().len();
+#[rocket::async_test]
+async fn create_user_json() {
+	common::as_admin(async move |http_client, db, _admin| {
+		let user_count = User::all(&db).await.unwrap().len();
 
 		let response = http_client
 			.post("/users")
@@ -289,20 +321,22 @@ fn create_user_json() {
 				 \"full_name\": \"abc\", \"email\": \"hij@klm.op\", \
 				 \"ssh_key\": \"ssh-rsa qrs tuv@wxyz\"}",
 			)
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(response.status(), Status::Ok);
 
-		assert_eq!(user_count + 1, User::all(&db).unwrap().len());
+		assert_eq!(user_count + 1, User::all(&db).await.unwrap().len());
 
-		let last_created = User::last(&db).unwrap();
+		let last_created = User::last(&db).await.unwrap();
 		assert_eq!("testuser", last_created.username);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn forgot_password() {
-	common::as_visitor(|http_client, db| {
+#[rocket::async_test]
+async fn forgot_password() {
+	common::as_visitor(async move |http_client, db| {
 		let email = String::from("test@example.com");
 		let user = User::create(
 			NewUser {
@@ -315,6 +349,7 @@ fn forgot_password() {
 			common::BCRYPT_COST,
 			&db,
 		)
+		.await
 		.unwrap();
 
 		assert!(user.password_reset_token.is_none());
@@ -323,7 +358,8 @@ fn forgot_password() {
 		let response = http_client
 			.get("/users/forgot_password")
 			.header(Accept::HTML)
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
@@ -331,14 +367,16 @@ fn forgot_password() {
 			"should get forgot password page"
 		);
 
-		let response = common::expect_mail_to(vec![&email], || {
+		let response = common::expect_mail_to(vec![&email], async || {
 			http_client
 				.post("/users/forgot_password")
 				.header(ContentType::Form)
 				.header(Accept::HTML)
 				.body(format!("for_email={}", &email))
 				.dispatch()
-		});
+				.await
+		})
+		.await;
 
 		assert_eq!(
 			response.status(),
@@ -346,7 +384,7 @@ fn forgot_password() {
 			"should post email to forgot password"
 		);
 
-		let user = user.reload(&db).unwrap();
+		let user = user.reload(&db).await.unwrap();
 
 		assert!(user.password_reset_token.is_some());
 		assert!(user.password_reset_expiry.is_some());
@@ -356,7 +394,8 @@ fn forgot_password() {
 		let response = http_client
 			.get(format!("/users/reset_password/{}", token,))
 			.header(Accept::HTML)
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(
 			response.status(),
@@ -369,7 +408,7 @@ fn forgot_password() {
 
 		dbg!(&user);
 
-		let response = common::expect_mail_to(vec![&email], || {
+		let response = common::expect_mail_to(vec![&email], async || {
 			http_client
 				.post(format!("/users/reset_password/"))
 				.header(ContentType::Form)
@@ -379,7 +418,9 @@ fn forgot_password() {
 					&token, &new_password
 				))
 				.dispatch()
-		});
+				.await
+		})
+		.await;
 
 		dbg!(&user);
 
@@ -389,18 +430,19 @@ fn forgot_password() {
 			"should post to reset password page"
 		);
 
-		let user = user.reload(&db).unwrap();
+		let user = user.reload(&db).await.unwrap();
 
 		assert!(user.password_reset_token.is_none());
 		assert!(user.password_reset_expiry.is_none());
 		assert_ne!(user.hashed_password, old_password_hash);
 		assert!(bcrypt::verify(new_password, &user.hashed_password));
-	});
+	})
+	.await;
 }
 
-#[test]
-fn forgot_password_non_existing_email() {
-	common::as_visitor(|http_client, db| {
+#[rocket::async_test]
+async fn forgot_password_non_existing_email() {
+	common::as_visitor(async move |http_client, db| {
 		let email = String::from("test@example.com");
 		let _user = User::create(
 			NewUser {
@@ -413,28 +455,32 @@ fn forgot_password_non_existing_email() {
 			common::BCRYPT_COST,
 			&db,
 		)
+		.await
 		.unwrap();
 
-		let response = common::dont_expect_mail(|| {
+		let response = common::dont_expect_mail(async || {
 			http_client
 				.post("/users/forgot_password")
 				.header(ContentType::Form)
 				.header(Accept::HTML)
 				.body("for_email=not_this_email@example.com")
 				.dispatch()
-		});
+				.await
+		})
+		.await;
 
 		assert_eq!(
 			response.status(),
 			Status::Ok,
 			"should still say everything is OK, even when email does not exist"
 		);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn reset_password_invalid_token() {
-	common::as_visitor(|http_client, db| {
+#[rocket::async_test]
+async fn reset_password_invalid_token() {
+	common::as_visitor(async move |http_client, db| {
 		let email = String::from("test@example.com");
 		let user = User::create(
 			NewUser {
@@ -447,6 +493,7 @@ fn reset_password_invalid_token() {
 			common::BCRYPT_COST,
 			&db,
 		)
+		.await
 		.unwrap();
 
 		let response = http_client
@@ -454,15 +501,16 @@ fn reset_password_invalid_token() {
 			.header(ContentType::Form)
 			.header(Accept::HTML)
 			.body(format!("for_email={}", &email))
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(response.status(), Status::Ok);
 
-		let user = user.reload(&db).unwrap();
+		let user = user.reload(&db).await.unwrap();
 		let token = user.password_reset_token.clone().unwrap();
 		let old_hash = user.hashed_password.clone();
 
-		let response = common::dont_expect_mail(|| {
+		let response = common::dont_expect_mail(async || {
 			http_client
 				.post("/users/reset_password/")
 				.header(ContentType::Form)
@@ -472,20 +520,26 @@ fn reset_password_invalid_token() {
 					&token, "passw0rd"
 				))
 				.dispatch()
-		});
+				.await
+		})
+		.await;
 
 		assert_eq!(response.status(), Status::Forbidden);
 
-		let user = user.reload(&db).unwrap();
+		let user = user.reload(&db).await.unwrap();
 		assert_eq!(user.hashed_password, old_hash);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn register_user() {
-	common::as_visitor(|http_client, db| {
-		let response =
-			http_client.get("/register").header(Accept::HTML).dispatch();
+#[rocket::async_test]
+async fn register_user() {
+	common::as_visitor(async move |http_client, db| {
+		let response = http_client
+			.get("/register")
+			.header(Accept::HTML)
+			.dispatch()
+			.await;
 
 		assert_eq!(response.status(), Status::Ok);
 
@@ -502,11 +556,13 @@ fn register_user() {
 				"username={}&password={}&full_name={}&email={}",
 				username, password, full_name, email
 			))
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(response.status(), Status::Created);
 
-		let user = User::find_by_username(username, &db)
+		let user = User::find_by_username(username.to_string(), &db)
+			.await
 			.expect("user should be created");
 
 		assert_eq!(
@@ -514,14 +570,18 @@ fn register_user() {
 			UserState::PendingApproval,
 			"registered users should be pending for approval"
 		);
-	});
+	})
+	.await;
 }
 
-#[test]
-fn validate_on_registration() {
-	common::as_visitor(|http_client, db| {
-		let response =
-			http_client.get("/register").header(Accept::HTML).dispatch();
+#[rocket::async_test]
+async fn validate_on_registration() {
+	common::as_visitor(async move |http_client, db| {
+		let response = http_client
+			.get("/register")
+			.header(Accept::HTML)
+			.dispatch()
+			.await;
 
 		assert_eq!(response.status(), Status::Ok);
 
@@ -530,7 +590,7 @@ fn validate_on_registration() {
 		let invalid_full_name = "?";
 		let email = "spaghet@zeus.ugent.be";
 
-		let user_count = User::all(&db).unwrap().len();
+		let user_count = User::all(&db).await.unwrap().len();
 
 		let response = http_client
 			.post("/register")
@@ -540,22 +600,27 @@ fn validate_on_registration() {
 				"username={}&password={}&full_name={}&email={}",
 				username, password, invalid_full_name, email
 			))
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(response.status(), Status::UnprocessableEntity);
 		assert_eq!(
 			user_count,
-			User::all(&db).unwrap().len(),
+			User::all(&db).await.unwrap().len(),
 			"should not have created user"
 		)
-	});
+	})
+	.await;
 }
 
-#[test]
-fn validate_on_admin_create() {
-	common::as_visitor(|http_client, db| {
-		let response =
-			http_client.get("/register").header(Accept::HTML).dispatch();
+#[rocket::async_test]
+async fn validate_on_admin_create() {
+	common::as_visitor(async move |http_client, db| {
+		let response = http_client
+			.get("/register")
+			.header(Accept::HTML)
+			.dispatch()
+			.await;
 
 		assert_eq!(response.status(), Status::Ok);
 
@@ -564,7 +629,7 @@ fn validate_on_admin_create() {
 		let invalid_full_name = "?";
 		let email = "spaghet@zeus.ugent.be";
 
-		let user_count = User::all(&db).unwrap().len();
+		let user_count = User::all(&db).await.unwrap().len();
 
 		let response = http_client
 			.post("/register")
@@ -574,13 +639,15 @@ fn validate_on_admin_create() {
 				"username={}&password={}&full_name={}&email={}",
 				username, password, invalid_full_name, email
 			))
-			.dispatch();
+			.dispatch()
+			.await;
 
 		assert_eq!(response.status(), Status::UnprocessableEntity);
 		assert_eq!(
 			user_count,
-			User::all(&db).unwrap().len(),
+			User::all(&db).await.unwrap().len(),
 			"should not have created user"
 		)
-	});
+	})
+	.await;
 }


### PR DESCRIPTION
This migrates our codebase to [Rocket version 5](https://github.com/SergioBenitez/Rocket/blob/master/CHANGELOG.md#version-050-rc1-jun-09-2021). There are a lot of changes and improvements, which is reflected by the amount of additions/deletions.

Major changes in this release of Rocket:
- changes to lifetime parameters of almost all traits
- a lot of stuff uses async/await now (i.e. the database) so almost all routes are now async
- tests needed to be migrated to async code as well because we need to talk to the database there
- the config has been rewritten to use a specialized crate, resulting in a better configuration interface

TODO:
- [ ] Update to a askama release instead of pinning a commit [because 0.11.0-rc.1 is broken](https://github.com/djc/askama/issues/524)
- [x] Finalize database setup (with seeding)
- [ ] Have others take a look at the code to suggest possible improvements