### PR TITLE
Allow all linebreaks

### DIFF
--- a/src/models/client.rs
+++ b/src/models/client.rs
@@ -101,6 +101,9 @@ impl Client {
 		}
 		if let Some(redirect_uri_list) = change.redirect_uri_list {
 			self.redirect_uri_list = redirect_uri_list
+				.split_whitespace()
+				.collect::<Vec<&str>>()
+				.join("\n")
 		}
 		Ok(())
 	}

--- a/src/models/client.rs
+++ b/src/models/client.rs
@@ -148,7 +148,7 @@ impl Client {
 
 	pub fn redirect_uri_acceptable(&self, redirect_uri: &str) -> bool {
 		self.redirect_uri_list
-			.split('\n')
+			.lines()
 			.any(|uri| uri == redirect_uri)
 	}
 


### PR DESCRIPTION
Carriage returns can be entered in the string in the browser and are correctly split now.

Fixes #48 