### PR TITLE
Fix network issues with cargo in GitHub actions

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -32,6 +32,10 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
+    - name: Fix network issues
+      run: |
+        mkdir .cargo
+        echo "[net] git-fetch-with-cli = true" > .cargo/config
     - name: Build Zauth
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
This could be caused by IPv6 (https://github.com/rust-lang/cargo/issues/9335).