### PR TITLE
Add flow for approved users to confirm their email

### DIFF
--- a/Rocket.toml
+++ b/Rocket.toml
@@ -2,6 +2,7 @@
 user_session_seconds = 604800              # 1 week
 client_session_seconds = 300               # 5 minutes
 authorization_token_seconds = 300          # 5 minutes
+email_confirmation_token_seconds = 604800  # 1 week
 admin_email = "admin@localhost"
 secure_token_length = 64
 bcrypt_cost = 12

--- a/migrations/2021-09-25-085355_add_email_confirmation/down.sql
+++ b/migrations/2021-09-25-085355_add_email_confirmation/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE users DROP COLUMN pending_email;
+ALTER TABLE users DROP COLUMN pending_email_token;
+ALTER TABLE users DROP COLUMN pending_email_expiry;
+DROP INDEX ix_users_email_token;

--- a/migrations/2021-09-25-085355_add_email_confirmation/up.sql
+++ b/migrations/2021-09-25-085355_add_email_confirmation/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+ALTER TABLE users ADD COLUMN pending_email VARCHAR(255);
+ALTER TABLE users ADD COLUMN pending_email_token VARCHAR(255) UNIQUE;
+ALTER TABLE users ADD COLUMN pending_email_expiry TIMESTAMP;
+
+CREATE INDEX ix_users_email_token ON users (pending_email_token);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,22 +1,24 @@
 use chrono::Duration;
 use lettre::message::Mailbox;
+use rocket::http::uri::Absolute;
 use rocket::serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(crate = "rocket::serde")]
 pub struct Config {
-	pub admin_email:                 String,
-	pub user_session_seconds:        i64,
-	pub client_session_seconds:      i64,
+	pub admin_email: String,
+	pub user_session_seconds: i64,
+	pub client_session_seconds: i64,
 	pub authorization_token_seconds: i64,
-	pub secure_token_length:         usize,
-	pub bcrypt_cost:                 u32,
-	pub base_url:                    String,
-	pub mail_queue_size:             usize,
-	pub mail_queue_wait_seconds:     u64,
-	pub mail_from:                   String,
-	pub mail_server:                 String,
-	pub maximum_pending_users:       usize,
+	pub email_confirmation_token_seconds: i64,
+	pub secure_token_length: usize,
+	pub bcrypt_cost: u32,
+	pub base_url: String,
+	pub mail_queue_size: usize,
+	pub mail_queue_wait_seconds: u64,
+	pub mail_from: String,
+	pub mail_server: String,
+	pub maximum_pending_users: usize,
 }
 
 impl Config {
@@ -30,6 +32,14 @@ impl Config {
 
 	pub fn authorization_token_duration(&self) -> Duration {
 		Duration::seconds(self.authorization_token_seconds)
+	}
+
+	pub fn email_confirmation_token_duration(&self) -> Duration {
+		Duration::seconds(self.email_confirmation_token_seconds)
+	}
+
+	pub fn base_url(&self) -> Absolute<'_> {
+		Absolute::parse(&self.base_url).expect("valid base_url")
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,8 @@ fn assemble(rocket: Rocket<Build>) -> Rocket<Build> {
 				users_controller::forgot_password_post,
 				users_controller::reset_password_get,
 				users_controller::reset_password_post,
+				users_controller::confirm_email_get,
+				users_controller::confirm_email_post,
 			],
 		)
 		.register(

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -6,6 +6,7 @@ use diesel_derive_enum::DbEnum;
 use std::fmt;
 
 use crate::models::user::UserState::{Active, PendingApproval};
+use crate::util::random_token;
 use crate::Config;
 use chrono::{NaiveDateTime, Utc};
 use lettre::message::Mailbox;
@@ -52,6 +53,9 @@ pub mod schema {
 			password_reset_expiry -> Nullable<Timestamp>,
 			full_name -> Varchar,
 			email -> Varchar,
+			pending_email -> Nullable<Varchar>,
+			pending_email_token -> Nullable<Varchar>,
+			pending_email_expiry -> Nullable<Timestamp>,
 			ssh_key -> Nullable<Text>,
 			state -> UserStateMapping,
 			last_login -> Timestamp,
@@ -79,6 +83,12 @@ pub struct User {
 	pub full_name:             String,
 	#[validate(email)]
 	pub email:                 String,
+	#[serde(skip)]
+	pub pending_email:         Option<String>,
+	#[serde(skip)]
+	pub pending_email_token:   Option<String>,
+	#[serde(skip)]
+	pub pending_email_expiry:  Option<NaiveDateTime>,
 	#[validate(custom = "validate_ssh_key_list")]
 	pub ssh_key:               Option<String>,
 	#[serde(skip)]
@@ -170,7 +180,7 @@ impl User {
 		Ok(())
 	}
 
-	pub async fn find_by_token<'r>(
+	pub async fn find_by_password_token<'r>(
 		token: String,
 		db: &DbConn,
 	) -> Result<Option<User>> {
@@ -190,6 +200,34 @@ impl User {
 			{
 				Ok(Some(user))
 			},
+			Ok(_) => Ok(None),
+			Err(ZauthError::NotFound(_)) => Ok(None),
+			Err(err) => Err(err),
+		}
+	}
+
+	fn email_token_valid(&self) -> bool {
+		if let Some(expiry) = self.pending_email_expiry {
+			return Utc::now().naive_utc() < expiry;
+		}
+		return false;
+	}
+
+	pub async fn find_by_email_token<'r>(
+		token: String,
+		db: &DbConn,
+	) -> Result<Option<User>> {
+		let token = token.to_owned();
+		let result = db
+			.run(move |conn| {
+				users::table
+					.filter(users::pending_email_token.eq(token))
+					.first::<Self>(conn)
+			})
+			.await
+			.map_err(ZauthError::from);
+		match result {
+			Ok(user) if user.email_token_valid() => Ok(Some(user)),
 			Ok(_) => Ok(None),
 			Err(ZauthError::NotFound(_)) => Ok(None),
 			Err(err) => Err(err),
@@ -253,6 +291,38 @@ impl User {
 			last_login:      Utc::now().naive_utc(),
 		};
 		Self::insert(user, db).await
+	}
+
+	pub async fn approve(mut self, conf: &Config, db: &DbConn) -> Result<User> {
+		if self.state == UserState::PendingApproval {
+			self.state = UserState::PendingMailConfirmation;
+		} else {
+			return Err(ZauthError::Unprocessable(String::from(
+				"user is not in the pending approval state",
+			)));
+		}
+		self.pending_email = Some(self.email.clone());
+		self.pending_email_token = Some(random_token(conf.secure_token_length));
+		self.pending_email_expiry = Some(
+			Utc::now().naive_utc() + conf.email_confirmation_token_duration(),
+		);
+		self.update(&db).await
+	}
+
+	pub async fn confirm_email(mut self, db: &DbConn) -> Result<User> {
+		if self.state == UserState::PendingMailConfirmation {
+			self.state = UserState::Active;
+		}
+		self.email = self
+			.pending_email
+			.as_ref()
+			.ok_or(ZauthError::Unprocessable(String::from(
+				"Valid confirmation token, but no pending email",
+			)))?
+			.to_string();
+		self.pending_email_token = None;
+		self.pending_email_expiry = None;
+		self.update(&db).await
 	}
 
 	async fn insert(user: NewUserHashed, db: &DbConn) -> Result<User> {

--- a/templates/errors/422.html
+++ b/templates/errors/422.html
@@ -1,0 +1,19 @@
+{% extends "base_error.html" %}
+
+<!-- Title -->
+{% block error_title %}
+  Unprocessable request
+{% endblock error_title %}
+
+<!-- Content -->
+{% block error_content %}
+<p>Sorry, but your request could not be processed because.
+  Probably because it would cause an illegal state.
+{% match message %}
+{% when Some with (msg) %}
+<p><strong>Message:</strong> {{ msg }}
+{% when None %}
+{% endmatch %}
+
+
+{% endblock error_content %}

--- a/templates/mails/confirm_user_registration.txt
+++ b/templates/mails/confirm_user_registration.txt
@@ -1,0 +1,10 @@
+Hi {{name}}
+
+Your account has been approved by an admin. Please finalize your registration
+by clicking on the following link to confirm your email:
+{{confirm_url}}
+
+Enjoy your time with Zeus WPI!
+
+Kind regards
+The Zeus Authentication Server

--- a/templates/users/confirm_email_form.html
+++ b/templates/users/confirm_email_form.html
@@ -1,0 +1,8 @@
+{% extends "../layout.html" %}
+{% block content %}
+    <h1>Confirm your email</h1>
+    <form action="/users/confirm" method="post">
+        <input type="hidden" name="token" value="{{ token }}">
+        <button type="submit">Confirm your email</button>
+    </form>
+{% endblock content %}

--- a/templates/users/confirm_email_invalid.html
+++ b/templates/users/confirm_email_invalid.html
@@ -1,0 +1,5 @@
+{% extends "../layout.html" %}
+{% block content %}
+<h1>Email confirmation token invalid.</h1>
+<p>Sorry, but the email confirmation link you used has expired or was invalid.</p>
+{% endblock content %}

--- a/templates/users/confirm_email_success.html
+++ b/templates/users/confirm_email_success.html
@@ -1,0 +1,5 @@
+{% extends "../layout.html" %}
+{% block content %}
+<h1>Your email has been confirmed!</h1>
+<p>You have sucessfully confirmed your email <strong>{{ email }}</strong>.
+{% endblock content %}

--- a/tests/oauth.rs
+++ b/tests/oauth.rs
@@ -12,7 +12,6 @@ use regex::Regex;
 use rocket::http::Header;
 use rocket::http::Status;
 use rocket::http::{Accept, ContentType};
-use rocket::http::{Cookie, CookieJar};
 
 use zauth::controllers::oauth_controller::UserToken;
 use zauth::models::client::{Client, NewClient};
@@ -21,7 +20,6 @@ use zauth::token_store::TokenStore;
 
 mod common;
 use crate::common::url;
-use crate::common::HttpClient;
 
 fn get_param(param_name: &str, query: &String) -> Option<String> {
 	Regex::new(&format!("{}=([^&]+)", param_name))


### PR DESCRIPTION
This completes the user registration flow by sending emails to new users to confirm their email.
This flow can also be used by users to change their email, but this is not implemented (yet).

I still need to change the order (first email confirmation, then admin approval).

**Warning:** this PR changes the database schema with a migration. I tested this locally and _in theory_ this should work flawlessly. At first boot, zauth will detect that a migration needs to be performed and run it. But it would be wise to take a backup first.
