### PR TITLE
Add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Parse tag
+        id: parse_tag
+        run: "echo ${{ github.ref }} | sed 's#^refs/tags/#::set-output name=version::#'"
+      - name: Create release
+        id: create_release
+        uses: release-drafter/release-drafter@v5
+        with:
+          name: ${{ steps.parse_tag.outputs.version }}
+          tag: ${{ steps.parse_tag.outputs.version }}
+          version: ${{ steps.parse_tag.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build the new image
+        run: docker build . -t ghcr.io/ZeusWPI/zauth:${{ steps.parse_tag.outputs.version }}
+      - name: Login to the container registry
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - name: Tag the new image with latest
+        run: docker tag ghcr.io/ZeusWPI/zauth:${{ steps.parse_tag.outputs.version }} ghcr.io/ZeusWPI/zauth:latest
+      - name: Push the new image
+        run: docker push --all-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build the new image
-        run: docker build . -t ghcr.io/ZeusWPI/zauth:${{ steps.parse_tag.outputs.version }}
+        run: docker build . -t ghcr.io/zeuswpi/zauth:${{ steps.parse_tag.outputs.version }}
       - name: Login to the container registry
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
       - name: Tag the new image with latest
-        run: docker tag ghcr.io/ZeusWPI/zauth:${{ steps.parse_tag.outputs.version }} ghcr.io/ZeusWPI/zauth:latest
+        run: docker tag ghcr.io/zeuswpi/zauth:${{ steps.parse_tag.outputs.version }} ghcr.io/zeuswpi/zauth:latest
       - name: Push the new image
         run: docker push --all-tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /usr/src/zauth
 
 RUN apt-get update && apt-get install -y netcat-openbsd sqlite3 libpq-dev libmariadbclient-dev ca-certificates
 COPY --from=builder /usr/local/cargo/bin/diesel /usr/local/cargo/bin/zauth /usr/local/bin/
-COPY Rocket.toml diesel.toml /usr/src/zauth/
+COPY diesel.toml /usr/src/zauth/
 COPY migrations/ migrations/
 COPY docker_misc/ docker_misc/
 COPY --from=staticbuilder /usr/src/zauth/static static/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - database
     command: >
       sh -c "./docker_misc/wait_for_service database 5432 && diesel --database-url 'postgresql://zauth:zauth@database/zauth' database setup && ROCKET_ENV=production zauth"
+    volumes:
+      - ${PWD}/Rocket.toml:/usr/src/zauth/Rocket.toml
 
   database:
     image: postgres:13-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
   zauth:
-    build: .
+    image: ghcr.io/ZeusWPI/zauth:latest
     ports:
       - "8000:8000"
     restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
   zauth:
-    image: ghcr.io/ZeusWPI/zauth:latest
+    image: ghcr.io/zeuswpi/zauth:latest
     ports:
       - "8000:8000"
     restart: on-failure

--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,7 @@ let
 in
 pkgs.mkShell {
   buildInputs = with pkgs; [
+    docker-compose
     rustNightlyTemp
     cargo-watch
     postgresql


### PR DESCRIPTION
When a tag is pushed, the workflow will:
- Create a GitHub release with release notes
- Build a docker image and publish it to `ghcr.io/ZeusWPI/zauth`

The `docker-compose.yml` has also been modified to use the latest image and to bind-mount the `Rocket.toml` config (a config change should not require a rebuild).