### PR TITLE
Change registration flow to confirm email first

### DIFF
--- a/migrations/2021-09-25-224437_change_registration_flow/down.sql
+++ b/migrations/2021-09-25-224437_change_registration_flow/down.sql
@@ -1,3 +1,2 @@
 -- This file should undo anything in `up.sql`
-ALTER TABLE users ALTER COLUMN email SET NOT NULL;
 ALTER TABLE users ALTER COLUMN state SET DEFAULT 'pending_approval';

--- a/migrations/2021-09-25-224437_change_registration_flow/down.sql
+++ b/migrations/2021-09-25-224437_change_registration_flow/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE users ALTER COLUMN email SET NOT NULL;
+ALTER TABLE users ALTER COLUMN state SET DEFAULT 'pending_approval';

--- a/migrations/2021-09-25-224437_change_registration_flow/up.sql
+++ b/migrations/2021-09-25-224437_change_registration_flow/up.sql
@@ -1,3 +1,2 @@
 -- Your SQL goes here
-ALTER TABLE users ALTER COLUMN email DROP NOT NULL;
 ALTER TABLE users ALTER COLUMN state SET DEFAULT 'pending_mail_confirmation';

--- a/migrations/2021-09-25-224437_change_registration_flow/up.sql
+++ b/migrations/2021-09-25-224437_change_registration_flow/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE users ALTER COLUMN email DROP NOT NULL;
+ALTER TABLE users ALTER COLUMN state SET DEFAULT 'pending_mail_confirmation';

--- a/templates/mails/confirm_user_registration.txt
+++ b/templates/mails/confirm_user_registration.txt
@@ -1,10 +1,13 @@
 Hi {{name}}
 
-Your account has been approved by an admin. Please finalize your registration
-by clicking on the following link to confirm your email:
+Welcome at Zeus WPI!
+Please confirm your email by clicking the following link:
 {{confirm_url}}
 
-Enjoy your time with Zeus WPI!
+After your email has been confirmed, an admin will need to approve your account. Once your account is approved, you will receive another email saying your account has been activated, after which you can enjoy the Zeus services.
+
+While waiting, you can create an account on our chat server over at
+https://mattermost.zeus.gent
 
 Kind regards
 The Zeus Authentication Server

--- a/templates/mails/user_approved.txt
+++ b/templates/mails/user_approved.txt
@@ -1,0 +1,10 @@
+Hi {{name}}
+
+Your account has been approved and you can now use our services with your
+account. You can use the following link to login:
+{{ login_url }}
+
+Enjoy your time with Zeus WPI!
+
+Kind regards
+The Zeus Authentication Server

--- a/templates/users/confirm_email_success.html
+++ b/templates/users/confirm_email_success.html
@@ -1,5 +1,10 @@
 {% extends "../layout.html" %}
 {% block content %}
 <h1>Your email has been confirmed!</h1>
-<p>You have sucessfully confirmed your email <strong>{{ email }}</strong>.
+<p>You have sucessfully confirmed your email <strong>{{ user.email }}</strong>.
+{% if !user.is_active() %}
+<p>Please wait until an admin approves your account.
+You will receive an email when your account has been approved and activated.
+Thank you for your patience.
+{% endif %}
 {% endblock content %}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,6 +12,7 @@ use diesel::RunQueryDsl;
 use parking_lot::Mutex;
 use std::str::FromStr;
 
+use crate::common::zauth::config::Config;
 use crate::common::zauth::models::client::*;
 use crate::common::zauth::models::user::*;
 use crate::common::zauth::DbConn;
@@ -28,10 +29,28 @@ pub type HttpClient = rocket::local::asynchronous::Client;
 // serialize tests.
 static DB_LOCK: Mutex<()> = Mutex::new(());
 
-pub const BCRYPT_COST: u32 = 4;
-
 pub fn url(content: &str) -> String {
 	urlencoding::encode(content).into_owned()
+}
+
+pub static BCRYPT_COST: u32 = 4;
+
+pub fn config() -> Config {
+	Config {
+		admin_email: "admin@example.com".to_string(),
+		user_session_seconds: 300,
+		client_session_seconds: 300,
+		authorization_token_seconds: 300,
+		email_confirmation_token_seconds: 300,
+		secure_token_length: 64,
+		bcrypt_cost: BCRYPT_COST,
+		base_url: "example.com".to_string(),
+		mail_queue_size: 10,
+		mail_queue_wait_seconds: 0,
+		mail_from: "zauth@example.com".to_string(),
+		mail_server: "stub".to_string(),
+		maximum_pending_users: 5,
+	}
 }
 
 async fn reset_db(db: &DbConn) {


### PR DESCRIPTION
This changes the registration flow such that users first have to confirm their email before an admin has to approve their account.