### PR TITLE
Fix compiler warnings and check token endpoint more thoroughly

### DIFF
--- a/src/controllers/pages_controller.rs
+++ b/src/controllers/pages_controller.rs
@@ -3,24 +3,16 @@ use rocket::response::{Redirect, Responder};
 use crate::controllers::users_controller::rocket_uri_macro_show_user;
 
 use crate::ephemeral::session::UserSession;
-use crate::errors::{Either, Result};
-use crate::models::client::Client;
-use crate::models::user::User;
-use crate::DbConn;
+use crate::errors::Either;
 
 #[get("/")]
-pub async fn home_page<'r>(
+pub fn home_page<'r>(
 	session: Option<UserSession>,
-	db: DbConn,
-) -> Result<Either<Redirect, impl Responder<'r, 'static>>> {
+) -> Either<Redirect, impl Responder<'r, 'static>> {
 	match session {
-		None => Ok(Either::Right(template! {
-			"pages/home.html";
-			clients:      Vec<Client>  = Client::all(&db).await?,
-			users:        Vec<User>    = User::all(&db).await?,
-		})),
+		None => Either::Right(template! {"pages/home.html"}),
 		Some(session) => {
-			Ok(Either::Left(Redirect::to(uri!(show_user(session.user.id)))))
+			Either::Left(Redirect::to(uri!(show_user(session.user.id))))
 		},
 	}
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -232,8 +232,6 @@ pub enum AuthenticationError {
 	Unauthorized(String),
 	#[error("Authentication failed")]
 	AuthFailed,
-	#[error("Invalid grant {0}")]
-	InvalidGrant(String),
 	#[error("Session expired")]
 	SessionExpired,
 }
@@ -258,8 +256,12 @@ pub enum OAuthError {
 	InvalidCookie,
 	#[error("Only response_type=code is supported")]
 	ResponseTypeMismatch,
+	#[error("Only grant_type=authorization_code is supported")]
+	GrantTypeMismatch,
 	#[error("Invalid request")]
 	InvalidRequest,
+	#[error("Invalid grant: {0}")]
+	InvalidGrant(String),
 }
 
 pub enum Either<R, E> {


### PR DESCRIPTION
This resolves all of the warnings shown by the compiler.
- The `AdminSession` and `ClientOrUserSession` did not use the `session` field in their struct, so it was removed.
- The homepage `/` still contained some old (debug) code fetching all users and clients without showing them, this was removed as well.
- The token endpoint (`/oauth/token`) did not verify whether the `grant_type` or `redirect_uri` parameters were correct, so checks were added for these parameters.

There is a possibility that the last point broke some clients not sending a `redirect_uri`, if that is the case then those clients deserve to be shamed thoroughly for not following the [OAuth2 RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3).