### PR TITLE
Use absolute path to authorize post URL

### DIFF
--- a/src/controllers/oauth_controller.rs
+++ b/src/controllers/oauth_controller.rs
@@ -113,6 +113,7 @@ pub async fn authorize<'r>(
 			cookies.add_private(state.into_cookie()?);
 			Ok(template! {
 				"oauth/authorize.html";
+				authorize_post_url: String = uri!(do_authorize).to_string(),
 				client_name: String = client_name,
 			})
 		} else {

--- a/templates/oauth/authorize.html
+++ b/templates/oauth/authorize.html
@@ -22,7 +22,7 @@
       </div>
 
       <!-- Form -->
-      <form class="is-flex" action="authorize" method="post">
+      <form class="is-flex" action="{{ authorize_post_url }}" method="post">
         <button class="button is-success is-medium" type="submit" name="authorized" value="true">Yes</button>
         <button class="button is-danger is-medium ml-2" type="submit" name="authorized" value="false">No</button>
       </form>


### PR DESCRIPTION
This fixes a bug when a trailing slash causes the POST to be directed to the wrong URL under certain conditions.