### PR TITLE
Add introspect (can hopefully be used for NGINX)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,7 +2829,7 @@ checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
 
 [[package]]
 name = "zauth"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "askama",
  "askama_rocket",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ fn assemble(rocket: Rocket<Build>) -> Rocket<Build> {
 				oauth_controller::grant_get,
 				oauth_controller::grant_post,
 				oauth_controller::token,
+				oauth_controller::introspect,
 				pages_controller::home_page,
 				sessions_controller::create_session,
 				sessions_controller::new_session,

--- a/tests/oauth.rs
+++ b/tests/oauth.rs
@@ -170,6 +170,25 @@ async fn normal_flow() {
 
 		assert_eq!(response.status(), Status::SeeOther);
 
+		let credentials =
+			base64::encode(&format!("{}:{}", client_id, client.secret));
+
+		let form_body = format!("token=1234");
+		let req = http_client
+			.post("/oauth/introspect")
+			.header(ContentType::Form)
+			.header(Header::new(
+				"Authorization",
+				format!("Basic {}", credentials),
+			))
+			.body(form_body);
+
+		let response = req.dispatch().await;
+		assert_eq!(response.status(), Status::Ok);
+		let response_body = response.into_string().await.expect("response body");
+		let data: Value = serde_json::from_str(&response_body).expect("response json values");
+		assert_eq!(data["active"], false);
+
 		// 7a. Client requests access code while sending its credentials
 		//     trough HTTP Auth.
 		let token_url = "/oauth/token";
@@ -177,9 +196,6 @@ async fn normal_flow() {
 			"grant_type=authorization_code&code={}&redirect_uri={}",
 			authorization_code, redirect_uri
 		);
-
-		let credentials =
-			base64::encode(&format!("{}:{}", client_id, client.secret));
 
 		let req = http_client
 			.post(token_url)
@@ -256,6 +272,22 @@ async fn normal_flow() {
 		assert_eq!(data["token_type"], "bearer");
 		let token = data["access_token"].as_str().expect("access token");
 
+		let form_body = format!("token={}", token);
+		let req = http_client
+			.post("/oauth/introspect")
+			.header(ContentType::Form)
+			.header(Header::new(
+				"Authorization",
+				format!("Basic {}", credentials),
+			))
+			.body(form_body);
+
+		let response = req.dispatch().await;
+		assert_eq!(response.status(), Status::Ok);
+		let response_body = response.into_string().await.expect("response body");
+		let data: Value = serde_json::from_str(&response_body).expect("response json values");
+		assert_eq!(data["active"], true);
+
 		let response = http_client
 			.get("/current_user")
 			.header(Accept::JSON)
@@ -276,6 +308,24 @@ async fn normal_flow() {
 
 		assert!(data["id"].is_number());
 		assert_eq!(data["username"], user_username);
+
+		http_client.post("/logout").dispatch().await;
+
+		let form_body = format!("token=1234");
+		let req = http_client
+			.post("/oauth/introspect")
+			.header(ContentType::Form)
+			.header(Header::new(
+				"Authorization",
+				format!("Basic {}", credentials),
+			))
+			.body(form_body);
+
+		let response = req.dispatch().await;
+		assert_eq!(response.status(), Status::Ok);
+		let response_body = response.into_string().await.expect("response body");
+		let data: Value = serde_json::from_str(&response_body).expect("response json values");
+		assert_eq!(data["active"], false);
 	})
 	.await;
 }


### PR DESCRIPTION
Standard: https://datatracker.ietf.org/doc/html/rfc7662#page-4

Hopefully works with https://www.nginx.com/blog/validating-oauth-2-0-access-tokens-nginx/