### PR TITLE
Show Zauth version in footer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ use std::str::FromStr;
 pub struct DbConn(PgConnection);
 pub type ConcreteConnection = PgConnection;
 
+pub const ZAUTH_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[get("/favicon.ico")]
 pub fn favicon() -> &'static str {
 	""

--- a/src/views/template.rs
+++ b/src/views/template.rs
@@ -5,8 +5,13 @@ macro_rules! template {
 			use askama::Template;
 			#[derive(Template, Debug)]
 			#[template(path = $template_name)]
-			struct TemplateStruct {}
-			TemplateStruct{}
+			struct TemplateStruct {
+				#[allow(dead_code)]
+				zauth_version: &'static str
+			}
+			TemplateStruct{
+				zauth_version: crate::ZAUTH_VERSION,
+			}
 		}
 	};
 
@@ -16,11 +21,14 @@ macro_rules! template {
 			#[derive(Template, Debug)]
 			#[template(path = $template_name)]
 			struct TemplateStruct {
+				#[allow(dead_code)]
+				zauth_version: &'static str,
 				$(
 					$name: $type,
 				)+
 			}
 			TemplateStruct {
+				zauth_version: crate::ZAUTH_VERSION,
 				$(
 					$name: $value,
 				)+

--- a/src/views/template.rs
+++ b/src/views/template.rs
@@ -9,7 +9,7 @@ macro_rules! template {
 				#[allow(dead_code)]
 				zauth_version: &'static str
 			}
-			TemplateStruct{
+			TemplateStruct {
 				zauth_version: crate::ZAUTH_VERSION,
 			}
 		}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -32,7 +32,7 @@
 			<div class="columns is-multiline is-justify-content-space-between">
 				<!-- Copyright -->
 				<div class="column is-narrow">
-					<a href="/">Zauth</a> by <a href="https://zeus.gent" target="_blank">Zeus WPI</a>
+					<a href="https://github.com/ZeusWPI/zauth/releases/tag/v{{ zauth_version }}">Zauth v{{ zauth_version }}</a> by <a href="https://zeus.gent" target="_blank">Zeus WPI</a>
 				</div>
 
 				<!-- Change theme -->


### PR DESCRIPTION
This will show the current Zauth version in the footer of each webpage, linking to the corresponding release.