### PR TITLE
fix(templates): use right source to check for subscription state

### DIFF
--- a/templates/users/show.html
+++ b/templates/users/show.html
@@ -50,7 +50,7 @@
 
 				<div class="field">
 					<label for="subscribed_to_mailing_list" class="label">Subscribe to Mailing List</label>
-					{% if current_user.subscribed_to_mailing_list -%}
+					{% if user.subscribed_to_mailing_list -%}
 						<input name="subscribed_to_mailing_list" type="checkbox" id="subscribed_to_mailing_list" checked>
 					{% else -%}
 						<input name="subscribed_to_mailing_list" type="checkbox" id="subscribed_to_mailing_list">


### PR DESCRIPTION
I think will fix what went wrong when Klaas or Ieben tried to unsubscribe someone from the mailinglist.
For what I can see the template had somehow access to `current_user` which represented them and why it looked like the checkbox was not working