### PR TITLE
Pin rocket_sync_db_pools dependency to 0.1.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ toml = "0.5"
 rand = "0.8"
 regex = "1.6"
 rocket = { version = "0.5.0-rc.2", features = [ "json", "secrets" ] }
-rocket_sync_db_pools = { version = "0.1.0-rc.2", features = [ "diesel_postgres_pool" ] }
+rocket_sync_db_pools = { version = "=0.1.0-rc.2", features = [ "diesel_postgres_pool" ] }
+rocket_sync_db_pools_codegen = { version = "=0.1.0-rc.2" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM rustlang/rust:nightly-buster AS builder
 
 WORKDIR /usr/src/zauth
 
-RUN cargo install diesel_cli
+RUN cargo install --version=1.4.1 diesel_cli
 COPY . .
 RUN cargo install --path .
 


### PR DESCRIPTION
(And its subdependency.)

This makes the docker image build locally for me.