### PR TITLE
Fix deleting clients

### DIFF
--- a/migrations/2023-10-26-0942_session_delete_cascade/down.sql
+++ b/migrations/2023-10-26-0942_session_delete_cascade/down.sql
@@ -1,0 +1,8 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE sessions
+    DROP CONSTRAINT sessions_client_id_fkey,
+    ADD CONSTRAINT sessions_client_id_fkey
+        FOREIGN KEY (client_id)
+        REFERENCES clients(id)
+        ON DELETE NO ACTION;

--- a/migrations/2023-10-26-0942_session_delete_cascade/up.sql
+++ b/migrations/2023-10-26-0942_session_delete_cascade/up.sql
@@ -1,0 +1,8 @@
+-- Your SQL goes here
+
+ALTER TABLE sessions
+    DROP CONSTRAINT sessions_client_id_fkey,
+    ADD CONSTRAINT sessions_client_id_fkey
+        FOREIGN KEY (client_id)
+        REFERENCES clients(id)
+        ON DELETE CASCADE;


### PR DESCRIPTION
Deleting clients with sessions would throw an error because of a constraint violation:
```
Internal error occurred: DatabaseError(DatabaseError(ForeignKeyViolation, "update or delete on table \"clients\" violates foreign key constraint \"sessions_client_id_fkey\" on table \"sessions\""))
```
This PR adds a test to reproduce this issue and fixes the issue by adding `ON DELETE CASCADE` to the foreign key constraint. This causes a delete on a client tot delete all associated sessions as well.

Are there any other relations where we want this to happen? I'm thinking of sessions referencing users (do we ever want to delete users?) etc.