### PR TITLE
prevent CORS error when using passkey with client

### DIFF
--- a/static/js/webauthn.js
+++ b/static/js/webauthn.js
@@ -78,17 +78,9 @@ function login_passkey() {
     }
     , (error) => null)
     .then((credential) => {
-        fetch('/webauthn/finish_auth', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                id: this.id,
-                credential: credential,
-            }),
-        })
-        .then(finish);
+        document.getElementById("webauthn-credential").value = JSON.stringify(credential);
+        document.getElementById("webauthn-id").value = JSON.stringify(this.id);
+        document.getElementById("webauthn").requestSubmit();
     })
 }
 

--- a/templates/session/login.html
+++ b/templates/session/login.html
@@ -43,6 +43,11 @@
        <button class="button is-primary" type="submit">Login</button>
       </form>
 
+	  <form id="webauthn" action="/webauthn/finish_auth", method="post">
+		<input name="credential" id="webauthn-credential" type="text" hidden />
+		<input name="id" id="webauthn-id" type="text" hidden />
+	  </form>
+
 	  <button class="button is-light" onclick="login_passkey()">With passkey</button>
 
 


### PR DESCRIPTION
After login using a passkey for a client, the browser should redirect to the callback. But this causes a CORS error (redirecting to a different domain in javascript)

This can be prevented by using a 'hidden' form and submitting it through JavaScript. In that way, no JavaScript code has to read the response of the post request.