### PR TITLE
make /user/username/keys endpoint return plaintext by default

### DIFF
--- a/templates/users/keys.html
+++ b/templates/users/keys.html
@@ -1,1 +1,1 @@
-<pre>{{keys}}</pre>
+{{keys}}


### PR DESCRIPTION
making endpoints able to return actual `text/plain` responses would require a fairly significant refactor, so i just edited the html template to remove the `<pre>` and `</pre>` tags. 
for end users this is equivalent to receiving plaintext (apart from the `Content-Type` header still being `text/html`).
